### PR TITLE
Take window size into consideration when rendering menu

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React from "react"
 
 import styles from "./menu.module.scss"
 

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -1,18 +1,15 @@
 import React, { Component } from "react"
+
 import styles from "./menu.module.scss"
 
-export default class Menu extends Component {
-  render() {
-    return (
-      <ul
-        className={`${styles.navigation} ${styles.closed} ${this.props
-          .menuIsOpen && styles.open} ${this.props.submenu &&
-          styles.submenu} ${this.props.menuIsOpen &&
-          this.props.submenu &&
-          styles.openSubmenu}`}
-      >
-        {this.props.children}
-      </ul>
-    )
-  }
-}
+const Menu = ({ children, menuIsOpen, submenu, windowIsLarge }) => (
+  <ul
+    className={`${styles.navigation} ${styles.closed} ${menuIsOpen && styles.open} ${submenu &&
+      styles.submenu} ${menuIsOpen && submenu && styles.openSubmenu}`
+    }
+  >
+    {(menuIsOpen || windowIsLarge) && children}
+  </ul>
+);
+
+export default Menu;

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -27,7 +27,7 @@ class Navbar extends Component {
           handleClick={this.handleClick}
           menuIsOpen={this.state.menuIsOpen}
         />
-        <Menu menuIsOpen={this.state.menuIsOpen}>
+        <Menu menuIsOpen={this.state.menuIsOpen} windowIsLarge={this.props.windowIsLarge}>
           {this.links.map((item, index) => (
             <NavbarItem
               key={index}

--- a/src/components/navbarItem.js
+++ b/src/components/navbarItem.js
@@ -50,8 +50,8 @@ class NavbarItem extends Component {
     return (
       <li
         className={`${styles.item} ${this.props.hidden && styles.hidden} ${this
-          .props.menuIsOpen && styles.open} ${this.props.submenu &&
-          styles.submenu}`}
+          .props.menuIsOpen && styles.open} ${this.props.submenu && styles.submenu}`
+        }
         key={`link item ${this.props.name}`}
         onClick={this.toggleMenu}
         onKeyUp={this.toggleMenu}
@@ -74,10 +74,20 @@ class NavbarItem extends Component {
           ) : null}
         </this.Anchor>
         {hasLinks ? (
-          <Menu menuIsOpen={this.state.menuItemIsOpen} submenu>
-            {this.props.links.map(({ position, endpoint }, index) => {
-              return <NavbarItem name={position} endpoint={endpoint} key={index} submenu />
-            })}
+          <Menu
+            menuIsOpen={this.state.menuItemIsOpen}
+            submenu
+            windowIsLarge={this.props.windowIsLarge}
+          >
+            {this.props.links.map(({ position, endpoint }, index) => (
+              <NavbarItem
+                endpoint={endpoint}
+                key={index}
+                name={position}
+                submenu
+                windowIsLarge={this.props.windowIsLarge}
+              />
+            ))}
           </Menu>
         ) : null}
       </li>


### PR DESCRIPTION
If we don't, then there is flickering when a user adjusts the screen size past the responsive breakpoint.

Gif:
![menu](https://user-images.githubusercontent.com/26235016/87105641-6c45cb00-c210-11ea-9be2-55756d1091c2.gif)
