### PR TITLE
Create bar chart component

### DIFF
--- a/src/components/barChart.js
+++ b/src/components/barChart.js
@@ -1,0 +1,71 @@
+import React from "react"
+import styles from "./barChart.module.scss"
+
+const percentFormatter = Intl.NumberFormat("en-US", { style: "percent" })
+const thousandsFormatter = Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+})
+
+function formatPercent(value) {
+  return percentFormatter.format(value)
+}
+
+function formatDollarsInThousands(value) {
+  return thousandsFormatter.format(value)
+}
+
+function Bar({ percent, type }) {
+  const colorStyle =
+    type === "expenditures" ? styles.expenditures : styles.contributions
+  return (
+    <div className={styles.barBackground}>
+      <div
+        className={`${styles.bar} ${colorStyle}`}
+        style={{ width: percent }}
+      />
+    </div>
+  )
+}
+
+function Row({ label, value, total, type, showPercentages }) {
+  const percent = formatPercent(value / total)
+  return (
+    <div className={styles.row}>
+      <p className={styles.label}>{label}</p>
+      <p className={styles.value}>
+        {showPercentages ? percent : formatDollarsInThousands(value)}
+      </p>
+      <div className={styles.barContainer}>
+        <Bar percent={percent} type={type} />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * A component to render a bar chart breaking down a candidate or measure's
+ * contributions or expenditures.
+ */
+export default function BarChart({
+  type = "contributions", // "contributions" | "expenditures"
+  total, // number
+  rows, // Array<{label: string, value: number}>
+  showPercentages = false, // Show percentages instead of dollar values
+}) {
+  return (
+    <div className={styles.chart}>
+      {rows.map(({ label, value }) => (
+        <Row
+          key={label}
+          label={label}
+          value={value}
+          total={total}
+          type={type}
+          showPercentages={showPercentages}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/barChart.module.scss
+++ b/src/components/barChart.module.scss
@@ -1,0 +1,63 @@
+$gray: #e7e7e7;
+$blue: #5fb2fb;
+$spendRed: #fb7b5f;
+
+p {
+  font-size: 2rem;
+}
+
+.bar {
+  border-radius: 0.8rem;
+  height: 100%;
+}
+
+.barBackground {
+  background-color: $gray;
+  border-radius: 0.8rem;
+  height: 1.6rem;
+  overflow: hidden;
+  width: 100%;
+}
+
+.barContainer {
+  align-self: center;
+  flex: 2;
+}
+
+.chart {
+  margin: 2.9rem 0;
+}
+
+.contributions {
+  background-color: $blue;
+}
+
+.expenditures {
+  background-color: $spendRed;
+}
+
+.label {
+  align-self: center;
+  flex: 1;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 2.9rem;
+}
+
+.value {
+  align-self: center;
+  flex: 1;
+  font-weight: bold;
+  margin-right: 1rem;
+  text-align: right;
+}
+
+@media screen and (max-width: 760px) {
+  .barContainer {
+    flex: 0 0 50%;
+  }
+}

--- a/src/pages/candidate.js
+++ b/src/pages/candidate.js
@@ -1,0 +1,40 @@
+import BarChart from "../components/barChart"
+import React from "react"
+import styles from "./candidate.module.scss"
+
+// TODO Hook up charts to real data
+const contributions = [
+  { label: "Individual", value: 500000 },
+  { label: "Committee", value: 400000 },
+  { label: "Self-funding", value: 14000 },
+  { label: "Other", value: 8000 },
+]
+
+const expenditures = [
+  { label: "Fundraising", value: 25000 },
+  { label: "Media", value: 18000 },
+  { label: "Administrative", value: 14000 },
+  { label: "Campaign salaries", value: 4000 },
+]
+
+const breakdowns = [
+  { label: "Out of State", value: 65487 },
+  { label: "Within California", value: 327438 },
+  { label: "Within San José", value: 301242 },
+]
+
+// TODO (#56) Create actual layout for this page
+export default function Candidate() {
+  return (
+    <div className={styles.container}>
+      <BarChart type="contributions" total={654876} rows={contributions} />
+      <BarChart type="expenditures" total={383254} rows={expenditures} />
+      <BarChart
+        type="contributions"
+        total={654876}
+        rows={breakdowns}
+        showPercentages
+      />
+    </div>
+  )
+}

--- a/src/pages/candidate.module.scss
+++ b/src/pages/candidate.module.scss
@@ -1,0 +1,3 @@
+.container {
+  padding: 2rem;
+}


### PR DESCRIPTION
Creating a <BarChart /> component that renders the contributions/expenditures charts from the candidate and measure pages. Mocks: https://www.figma.com/file/GmfndRmQChBeoklOkmi0FC/Open-Disclosure?node-id=1433%3A1563

Also stubbed out a `/candidate` page that just renders three charts with mock data, for now. It needs an actual layout, and to be hooked up to real data.

The one UX issue that I'm still not super happy with is how the border radius on the bar looks when the value is really small - it still applies the same border radius, which makes it look... squished.

<img width="477" alt="Screen Shot 2020-08-12 at 4 24 58 PM" src="https://user-images.githubusercontent.com/2308395/90078416-ae53a800-dcb9-11ea-88cb-d2debea9160b.png">

I think my preference would be to remove or change the border radius when width < height, but I'm not sure the best way to do that (is this something I can do in CSS?). From the mocks it's not totally clear how this should be handled - the one example I found on the measure page seems to show no border radius at all, which doesn't seem quite right: 

<img width="585" alt="Screen Shot 2020-08-12 at 4 35 42 PM" src="https://user-images.githubusercontent.com/2308395/90078479-e955db80-dcb9-11ea-8fc4-58baf8421a07.png">

Here's what the page looks like for large & small sizes:

<img width="1437" alt="Screen Shot 2020-08-12 at 4 26 15 PM" src="https://user-images.githubusercontent.com/2308395/90078550-1904e380-dcba-11ea-99c8-cf57d585146a.png">

<img width="300" alt="Screen Shot 2020-08-12 at 4 25 05 PM" src="https://user-images.githubusercontent.com/2308395/90078561-24580f00-dcba-11ea-830b-49fff3561a78.png">

Closes #74 