### PR TITLE
Create components for Candidate page

### DIFF
--- a/src/components/barChart.module.scss
+++ b/src/components/barChart.module.scss
@@ -2,10 +2,6 @@ $gray: #e7e7e7;
 $blue: #5fb2fb;
 $spendRed: #fb7b5f;
 
-p {
-  font-size: 2rem;
-}
-
 .bar {
   border-radius: 0.8rem;
   height: 100%;
@@ -26,6 +22,10 @@ p {
 
 .chart {
   margin: 2.9rem 0;
+
+  p {
+    font-size: 2rem;
+  }
 }
 
 .contributions {

--- a/src/components/sectionHeader.js
+++ b/src/components/sectionHeader.js
@@ -1,0 +1,11 @@
+import React from "react"
+import styles from "./sectionHeader.module.scss"
+
+export default function SectionHeader({ title }) {
+  return (
+    <>
+      <h3>{title}</h3>
+      <div className={styles.divider} />
+    </>
+  )
+}

--- a/src/components/sectionHeader.module.scss
+++ b/src/components/sectionHeader.module.scss
@@ -1,0 +1,12 @@
+$gray: #e7e7e7;
+
+h3 {
+  font-size: 3.2rem;
+  font-weight: bold;
+}
+
+.divider {
+  width: 100%;
+  border: 0.2rem solid $gray;
+  margin: 2.4rem 0;
+}

--- a/src/components/totalAmountItem.js
+++ b/src/components/totalAmountItem.js
@@ -1,0 +1,57 @@
+import React from "react"
+import styles from "./totalAmountItem.module.scss"
+
+const currencyFormatter = Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+})
+
+function formatDollars(value) {
+  return currencyFormatter.format(value)
+}
+
+function title(type) {
+  if (type === "expenditures") {
+    return "Total spent"
+  } else if (type === "balance") {
+    return "Current balance"
+  } else {
+    return "Total raised"
+  }
+}
+
+function detail(type) {
+  let detail
+  if (type === "expenditures") {
+    detail = "Expenditures"
+  } else if (type === "balance") {
+    detail = "Cash on hand"
+  } else {
+    detail = "Contributions"
+  }
+  return " (" + detail + ")"
+}
+
+export default function TotalAmountItem({ total, type = "contributions" }) {
+  return (
+    <>
+      <p className={styles.header}>
+        <span className={styles.title}>{title(type)}</span>
+        {detail(type)}
+      </p>
+      <p className={styles.value}>{formatDollars(total)}</p>
+    </>
+  )
+}
+
+export function TotalAmountPanelItem({ total, type = "contributions" }) {
+  return (
+    <div className={styles.panel}>
+      <p className={styles.title}>{title(type)}</p>
+      <p className={styles.header}>{detail(type)}</p>
+      <p className={styles.value}>{formatDollars(total)}</p>
+    </div>
+  )
+}

--- a/src/components/totalAmountItem.module.scss
+++ b/src/components/totalAmountItem.module.scss
@@ -1,0 +1,22 @@
+.panel {
+  text-align: center;
+
+  .value {
+    font-weight: bold;
+    margin: 2.4rem 0;
+  }
+}
+
+.header {
+  font-size: 2.4rem;
+}
+
+.title {
+  font-size: 2.8rem;
+  font-weight: bold;
+}
+
+.value {
+  font-size: 3.6rem;
+  margin: 1.6rem 0;
+}

--- a/src/pages/candidate.js
+++ b/src/pages/candidate.js
@@ -1,3 +1,7 @@
+import TotalAmountItem, {
+  TotalAmountPanelItem,
+} from "../components/totalAmountItem"
+
 import BarChart from "../components/barChart"
 import React from "react"
 import styles from "./candidate.module.scss"
@@ -27,8 +31,16 @@ const breakdowns = [
 export default function Candidate() {
   return (
     <div className={styles.container}>
+      <div className={styles.totals}>
+        <TotalAmountPanelItem type="contributions" total={654876} />
+        <TotalAmountPanelItem type="expenditures" total={383254} />
+        <TotalAmountPanelItem type="balance" total={271622} />
+      </div>
+      <TotalAmountItem type="contributions" total={654876} />
       <BarChart type="contributions" total={654876} rows={contributions} />
+      <TotalAmountItem type="expenditures" total={383254} />
       <BarChart type="expenditures" total={383254} rows={expenditures} />
+      <TotalAmountItem type="contributions" total={654876} />
       <BarChart
         type="contributions"
         total={654876}

--- a/src/pages/candidate.js
+++ b/src/pages/candidate.js
@@ -28,28 +28,45 @@ const breakdowns = [
   { label: "Within San José", value: 301242 },
 ]
 
+function ChartSection({ title, type, total, data, ...passProps }) {
+  return (
+    <section>
+      <SectionHeader title={title} />
+      <TotalAmountItem type={type} total={total} />
+      <BarChart type={type} total={total} rows={data} {...passProps} />
+    </section>
+  )
+}
+
 // TODO (#56) Create actual layout for this page
 export default function Candidate() {
   return (
     <div className={styles.container}>
-      <SectionHeader title="Fundraising totals" />
-      <div className={styles.totals}>
-        <TotalAmountPanelItem type="contributions" total={654876} />
-        <TotalAmountPanelItem type="expenditures" total={383254} />
-        <TotalAmountPanelItem type="balance" total={271622} />
-      </div>
-      <SectionHeader title="Where the money is coming from" />
-      <TotalAmountItem type="contributions" total={654876} />
-      <BarChart type="contributions" total={654876} rows={contributions} />
-      <SectionHeader title="How the money is being spent" />
-      <TotalAmountItem type="expenditures" total={383254} />
-      <BarChart type="expenditures" total={383254} rows={expenditures} />
-      <SectionHeader title="Breakdown by region" />
-      <TotalAmountItem type="contributions" total={654876} />
-      <BarChart
+      <section>
+        <SectionHeader title="Fundraising totals" />
+        <div className={styles.totals}>
+          <TotalAmountPanelItem type="contributions" total={654876} />
+          <TotalAmountPanelItem type="expenditures" total={383254} />
+          <TotalAmountPanelItem type="balance" total={271622} />
+        </div>
+      </section>
+      <ChartSection
+        title="Where the money is coming from"
         type="contributions"
         total={654876}
-        rows={breakdowns}
+        data={contributions}
+      />
+      <ChartSection
+        title="How the money is being spent"
+        type="expenditures"
+        total={383254}
+        data={expenditures}
+      />
+      <ChartSection
+        title="Breakdown by region"
+        type="contributions"
+        total={654876}
+        data={breakdowns}
         showPercentages
       />
     </div>

--- a/src/pages/candidate.js
+++ b/src/pages/candidate.js
@@ -4,6 +4,7 @@ import TotalAmountItem, {
 
 import BarChart from "../components/barChart"
 import React from "react"
+import SectionHeader from "../components/sectionHeader"
 import styles from "./candidate.module.scss"
 
 // TODO Hook up charts to real data
@@ -31,15 +32,19 @@ const breakdowns = [
 export default function Candidate() {
   return (
     <div className={styles.container}>
+      <SectionHeader title="Fundraising totals" />
       <div className={styles.totals}>
         <TotalAmountPanelItem type="contributions" total={654876} />
         <TotalAmountPanelItem type="expenditures" total={383254} />
         <TotalAmountPanelItem type="balance" total={271622} />
       </div>
+      <SectionHeader title="Where the money is coming from" />
       <TotalAmountItem type="contributions" total={654876} />
       <BarChart type="contributions" total={654876} rows={contributions} />
+      <SectionHeader title="How the money is being spent" />
       <TotalAmountItem type="expenditures" total={383254} />
       <BarChart type="expenditures" total={383254} rows={expenditures} />
+      <SectionHeader title="Breakdown by region" />
       <TotalAmountItem type="contributions" total={654876} />
       <BarChart
         type="contributions"

--- a/src/pages/candidate.module.scss
+++ b/src/pages/candidate.module.scss
@@ -1,3 +1,10 @@
 .container {
   padding: 2rem;
 }
+
+.totals {
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 4.7rem;
+  margin-bottom: 7.8rem;
+}

--- a/src/pages/candidate.module.scss
+++ b/src/pages/candidate.module.scss
@@ -4,7 +4,13 @@
 
 .totals {
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-around;
   margin-top: 4.7rem;
   margin-bottom: 7.8rem;
+}
+
+@media screen and (max-width: 760px) {
+  .totals {
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
Creating a couple of components to be used in the Candidate page and adding them to the stubbed-out page. This PR includes a component to render the section header (h3 + divider line) as well as the formatted dollar value + label for contribution/expenditure totals.

The TotalAmountItem component needs to look slightly different depending on where it's rendered. The easiest way I found to do that was just to export a second component (TotalAmountPanelItem) from the same file, so it can share the logic and CSS with the non-panel version that appears above all the charts. I guess I could also use a prop for this instead - not sure which makes more sense.

<img width="1109" alt="Screen Shot 2020-08-13 at 3 00 32 PM" src="https://user-images.githubusercontent.com/2308395/90192661-3dbf9080-dd78-11ea-9323-b8e610319785.png">
<img width="400" alt="Screen Shot 2020-08-13 at 3 04 55 PM" src="https://user-images.githubusercontent.com/2308395/90192670-431cdb00-dd78-11ea-999f-3a4cb1bd1e7a.png">
