### PR TITLE
Color variables

### DIFF
--- a/src/common/button/styles.module.scss
+++ b/src/common/button/styles.module.scss
@@ -16,12 +16,12 @@
     font-family: "DM Sans";
     font-weight: bold;
     font-size: resize(20);
-    color: #fff;
+    color: $primaryWhite;
   }
 }
 
 .secondary {
-  background-color: #fff;
+  background-color: $primaryWhite;
 
   .buttonText {
     color: $primaryGreen;
@@ -38,7 +38,7 @@
   border-color: $primaryGreen;
 
   .buttonText {
-    color: #fff;
+    color: $primaryWhite;
   }
 }
 

--- a/src/common/button/styles.module.scss
+++ b/src/common/button/styles.module.scss
@@ -1,5 +1,4 @@
-$primaryGreen: #008254;
-$secondaryGreen: #025B3C;
+@import "../../styles/colors";
 
 // Resizes Figma values to a 6:5 ratio and converts to rem
 @function resize($size) {
@@ -30,8 +29,8 @@ $secondaryGreen: #025B3C;
 }
 
 .container:hover {
-  background-color: $secondaryGreen;
-  border-color: $secondaryGreen;
+  background-color: $hoverGreen;
+  border-color: $hoverGreen;
 }
 
 .secondary:hover {

--- a/src/common/hamburgerIcon/styles.module.scss
+++ b/src/common/hamburgerIcon/styles.module.scss
@@ -1,3 +1,5 @@
+@import "../../styles/colors";
+
 .hamburgerShell {
   display: none;
 }
@@ -22,7 +24,7 @@
     position: absolute;
     width: 2rem;
     height: 0.3rem;
-    background-color: black;
+    background-color: $primaryBlack;
     transition: all 350ms ease-in-out;
     top: 1.8rem;
   }

--- a/src/components/barChart.module.scss
+++ b/src/components/barChart.module.scss
@@ -1,6 +1,4 @@
-$gray: #e7e7e7;
-$blue: #5fb2fb;
-$spendRed: #fb7b5f;
+@import "../styles/colors";
 
 .bar {
   border-radius: 0.8rem;
@@ -8,7 +6,7 @@ $spendRed: #fb7b5f;
 }
 
 .barBackground {
-  background-color: $gray;
+  background-color: $backgroundGray;
   border-radius: 0.8rem;
   height: 1.6rem;
   overflow: hidden;
@@ -29,11 +27,11 @@ $spendRed: #fb7b5f;
 }
 
 .contributions {
-  background-color: $blue;
+  background-color: $supportBlue;
 }
 
 .expenditures {
-  background-color: $spendRed;
+  background-color: $opposeRed;
 }
 
 .label {

--- a/src/components/behindTheScenesItem.module.scss
+++ b/src/components/behindTheScenesItem.module.scss
@@ -1,4 +1,4 @@
-$primaryBlack: #1b1b1b;
+@import "../styles/colors";
 
 .container {
   flex: 1;

--- a/src/components/candidateItem.module.scss
+++ b/src/components/candidateItem.module.scss
@@ -1,7 +1,4 @@
-$primaryGreen: #008254;
-$primaryWhite: #fff;
-$secondaryGreen: #e3f9f1;
-$secondaryBlue: #deeffe;
+@import "../styles/colors";
 
 .container {
   background-color: transparent;

--- a/src/components/candidateItem.module.scss
+++ b/src/components/candidateItem.module.scss
@@ -6,7 +6,7 @@
 
   img {
     align-self: center;
-    background-color: #fff;
+    background-color: $primaryWhite;
     border: 8px solid $secondaryBlue;
     border-radius: 50%;
     max-height: 18rem;
@@ -41,7 +41,7 @@
     }
 
     p {
-      color: #555555;
+      color: $darkGray;
       font-size: 1.4rem;
       line-height: 1.82rem;
     }

--- a/src/components/faqItem.module.scss
+++ b/src/components/faqItem.module.scss
@@ -1,4 +1,4 @@
-$secondaryGray: #f2f2f2;
+@import "../styles/colors";
 
 .container {
   background-color: $secondaryGray;

--- a/src/components/faqItem.module.scss
+++ b/src/components/faqItem.module.scss
@@ -34,7 +34,7 @@
 .horizontalBar,
 .verticalBar {
   position: absolute;
-  background-color: #000;
+  background-color: $primaryBlack;
   transition: transform 250ms ease-in-out;
 }
 

--- a/src/components/landingPageHero.module.scss
+++ b/src/components/landingPageHero.module.scss
@@ -1,4 +1,4 @@
-$primaryOffWhite: #fafafa;
+@import "../styles/colors";
 
 .hero {
   padding: 9.5rem 8.5rem;

--- a/src/components/layout.module.scss
+++ b/src/components/layout.module.scss
@@ -1,7 +1,7 @@
 @import "../styles/colors";
 
 .footer {
-  background-color: #fafafa;
+  background-color: $primaryOffWhite;
   padding: 0 6rem;
 }
 
@@ -66,7 +66,7 @@
 .emailInput {
   background-color: transparent;
   border: none;
-  color: #555555;
+  color: $darkGray;
   flex: 2;
   padding: 1.3rem 2rem;
 }
@@ -76,7 +76,7 @@
 .emailInput:-ms-input-placeholder,
 .emailInput::-moz-placeholder,
 .emailInput:-moz-placeholder {
-  color: #555555;
+  color: $darkGray;
   opacity: 1;
 }
 
@@ -84,7 +84,7 @@
   background-color: $primaryGreen;
   border: solid 2px $primaryGreen;
   border-radius: 0 4px 4px 0;
-  color: #fafafa;
+  color: $primaryOffWhite;
   flex: 1;
   font-family: "DM Sans";
   font-weight: bold;

--- a/src/components/layout.module.scss
+++ b/src/components/layout.module.scss
@@ -1,6 +1,4 @@
-$primaryBlack: #1b1b1b;
-$primaryGreen: #008254;
-$hoverGreen: #025b3c;
+@import "../styles/colors";
 
 .footer {
   background-color: #fafafa;

--- a/src/components/logo.module.scss
+++ b/src/components/logo.module.scss
@@ -1,4 +1,4 @@
-$hoverGreen: #025b3c;
+@import "../styles/colors";
 
 .logo {
   color: $hoverGreen;

--- a/src/components/mainPageSection.module.scss
+++ b/src/components/mainPageSection.module.scss
@@ -1,6 +1,4 @@
-$primaryGreen: #008254;
-$primaryWhite: #fff;
-$primaryOffWhite: #fafafa;
+@import "../styles/colors";
 
 .outerContainer {
   background-color: $primaryWhite;

--- a/src/components/navbar.module.scss
+++ b/src/components/navbar.module.scss
@@ -1,7 +1,4 @@
-$primaryBlack: #1b1b1b;
-$primaryWhite: #fff;
-$secondaryGreen: #e3f9f1;
-$hoverGreen: #025b3c;
+@import "../styles/colors";
 
 .navbar {
   align-items: center;

--- a/src/components/navbarItem.module.scss
+++ b/src/components/navbarItem.module.scss
@@ -1,7 +1,4 @@
-$primaryBlack: #1b1b1b;
-$primaryWhite: #fff;
-$secondaryGreen: #e3f9f1;
-$hoverGreen: #025b3c;
+@import "../styles/colors";
 
 .item {
   font-size: 1.8rem;

--- a/src/components/registerToVoteCard.module.scss
+++ b/src/components/registerToVoteCard.module.scss
@@ -1,5 +1,4 @@
-$secondaryGreen: #e3f9f1;
-$secondaryBlue: #deeffe;
+@import "../styles/colors";
 
 .card {
   flex: 1;

--- a/src/components/sectionHeader.module.scss
+++ b/src/components/sectionHeader.module.scss
@@ -1,4 +1,4 @@
-$gray: #e7e7e7;
+@import "../styles/colors";
 
 h3 {
   font-size: 3.2rem;
@@ -7,6 +7,6 @@ h3 {
 
 .divider {
   width: 100%;
-  border: 0.2rem solid $gray;
+  border: 0.2rem solid $backgroundGray;
   margin: 2.4rem 0;
 }

--- a/src/components/snapshotItem.module.scss
+++ b/src/components/snapshotItem.module.scss
@@ -1,4 +1,4 @@
-$primaryOffWhite: #fafafa;
+@import "../styles/colors";
 
 .container {
   align-items: center;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -1,8 +1,3 @@
-$primaryBlack: #1b1b1b;
-$primaryGreen: #008254;
-$secondaryGreen: #eafff7;
-$underline: #00825466;
-
 .container {
   .hero {
     flex-direction: row;

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,0 +1,20 @@
+// Primary palette
+$primaryGreen: #008254;
+$primaryBlack: #1b1b1b;
+$primaryOffWhite: #fafafa;
+$primaryWhite: #ffffff;
+
+// Secondary palette
+$secondaryGreen: #e3f9f1;
+$secondaryYellow: #feefd0;
+$secondaryBlue: #deeffe;
+$secondaryGray: #f2f2f2;
+$darkGray: #555555;
+$secondaryWhite: #e5e5e5;
+
+// Special-purpose colors
+$underline: #00825466;
+$hoverGreen: #025b3c;
+$supportBlue: #5fb2fb;
+$opposeRed: #fb7b5f;
+$backgroundGray: #e7e7e7;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,9 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap");
-
-$primaryBlack: #1b1b1b;
-$primaryGreen: #008254;
-$secondaryGreen: #eafff7;
-$underline: #00825466;
+@import "colors";
 
 * {
   padding: 0;


### PR DESCRIPTION
Moving all color variable definitions to a single .scss file and using `@import` to use those variables everywhere else. I (mostly) used [the palette in Figma](https://www.figma.com/file/GmfndRmQChBeoklOkmi0FC/Open-Disclosure?node-id=2029%3A0), but there were a few things missing that I left in and made up a name for.

Also cleaning up some of the places where we still use hex values in our .scss files - I mostly just used the variable with the same hex value, except for the places where 'black' or #000 was used, which I swapped for $primaryBlack. I left the .css files alone.