### PR TITLE
Plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,6 @@
  *
  * See: https://www.gatsbyjs.org/docs/gatsby-config/
  */
-const hostname = process.env.GATSBY_API_SERVER ?? "localhost:5000"
 
 module.exports = {
   plugins: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,27 +8,7 @@ const hostname = process.env.GATSBY_API_SERVER ?? "localhost:5000"
 module.exports = {
   plugins: [
     `gatsby-plugin-sass`,
-    {
-      resolve: "gatsby-source-apiserver",
-      options: {
-        url: `http://${hostname}/open-disclosure/api/v1.0/candidates`,
-        method: "get",
-        data: {},
-        name: `candidate`,
-        entityLevel: `Candidates`,
-        schemaType: {
-          Name: "String",
-          Elections: [
-            {
-              ElectionCycle: "String",
-              ElectionTitle: "String",
-              Committees: [{ Name: "String", TotalFunding: 1 }],
-            },
-          ],
-        },
-        enableDevRefresh: true,
-      },
-    },
+    `source-api-plugin`,
     {
       resolve: "gatsby-plugin-slug-field",
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,10 +12,6 @@ exports.createPages = async ({ graphql, actions }) => {
             fields {
               slug
             }
-            Elections {
-              ElectionCycle
-              ElectionTitle
-            }
           }
         }
       }

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -33,6 +33,14 @@ exports.sourceNodes = async ({
     )
     data = await response.json()
   } catch (networkError) {
+    console.warn(
+      "Unable to reach the API server at " +
+        HOSTNAME +
+        ", falling back to mock data"
+    )
+    console.info(
+      "Use the environment variable GATSBY_API_HOST to use a different hostname for the API server"
+    )
     // Use dummy data as a fallback in case the API isn't available.
     // TODO This is only for development purposes - get rid of this
     data = DUMMY_DATA

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -1,0 +1,41 @@
+const CANDIDATE_NODE_TYPE = `candidate`
+
+exports.sourceNodes = async ({
+  actions,
+  createNodeId,
+  createContentDigest,
+  getNodesByType,
+}) => {
+  const { createNode } = actions
+
+  // This can become fallback data?
+  const data = {
+    Candidates: [
+      {
+        Name: "Lindsay Lohan",
+        Elections: [
+          {
+            ElectionCycle: "2020 Election Cycle",
+            ElectionTitle: "District 9 Representative",
+            Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
+          },
+        ],
+      },
+    ],
+  }
+
+  data.Candidates.forEach(candidate => {
+    createNode({
+      ...candidate,
+      id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: CANDIDATE_NODE_TYPE,
+        content: JSON.stringify(candidate),
+        contentDigest: createContentDigest(candidate),
+      },
+    })
+  })
+  return
+}

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -1,27 +1,41 @@
+const fetch = require("node-fetch")
+
+// TODO Add dev/prod variations
+const HOSTNAME = process.env.GATSBY_API_HOST || "localhost:5000"
 const CANDIDATE_NODE_TYPE = `candidate`
+
+const DUMMY_DATA = {
+  Candidates: [
+    {
+      Name: "Lindsay Lohan",
+      Elections: [
+        {
+          ElectionCycle: "2020 Election Cycle",
+          ElectionTitle: "District 9 Representative",
+          Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
+        },
+      ],
+    },
+  ],
+}
 
 exports.sourceNodes = async ({
   actions,
   createNodeId,
   createContentDigest,
-  getNodesByType,
 }) => {
   const { createNode } = actions
 
-  // This can become fallback data?
-  const data = {
-    Candidates: [
-      {
-        Name: "Lindsay Lohan",
-        Elections: [
-          {
-            ElectionCycle: "2020 Election Cycle",
-            ElectionTitle: "District 9 Representative",
-            Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
-          },
-        ],
-      },
-    ],
+  let data
+  try {
+    const response = await fetch(
+      `http://${HOSTNAME}/open-disclosure/api/v1.0/candidates`
+    )
+    data = await response.json()
+  } catch (networkError) {
+    // Use dummy data as a fallback in case the API isn't available.
+    // TODO This is only for development purposes - get rid of this
+    data = DUMMY_DATA
   }
 
   data.Candidates.forEach(candidate => {

--- a/plugins/source-api-plugin/package.json
+++ b/plugins/source-api-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "source-api-plugin",
+  "version": "1.0.0",
+  "description": "Source plugin for fetching data from the api"
+}

--- a/src/pages/candidates.js
+++ b/src/pages/candidates.js
@@ -5,13 +5,11 @@ import React from "react"
 export default function Candidates({ data }) {
   return (
     <ul>
-      {data.allCandidate.edges
-        .filter(({ node }) => node.id !== "dummy")
-        .map(({ node }) => (
-          <li key={node.id}>
-            <Link to={"/candidate/" + node.fields.slug}>{node.Name}</Link>
-          </li>
-        ))}
+      {data.allCandidate.edges.map(({ node }) => (
+        <li key={node.id}>
+          <Link to={"/candidate/" + node.fields.slug}>{node.Name}</Link>
+        </li>
+      ))}
     </ul>
   )
 }

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -97,7 +97,6 @@ export const query = graphql`
     candidate(fields: { slug: { eq: $slug } }) {
       Name
       Elections {
-        ElectionCycle
         ElectionTitle
       }
     }


### PR DESCRIPTION
Fixes #93. The plugin I was using for fetching data from the API didn't gracefully handle the case that the API wasn't available at all and `fetch` threw an error - this meant if you weren't running the flask server, gatsby would actually fail to build, and you couldn't do anything. Instead of using that plugin, this PR adds our own local plugin that pretty much does the same thing (and adds a try/catch).

Also remove the `??` operator which was causing issues.