### PR TITLE
Fetch data from /elections endpoint, add GraphQL queries to index.js

### DIFF
--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -3,35 +3,56 @@ const fetch = require("node-fetch")
 // TODO Add dev/prod variations
 const HOSTNAME = process.env.GATSBY_API_HOST || "localhost:5000"
 const CANDIDATE_NODE_TYPE = `candidate`
+const ELECTION_NODE_TYPE = `election`
 
 const DUMMY_DATA = {
-  Candidates: [
-    {
-      Name: "Lindsay Lohan",
-      Elections: [
-        {
-          ElectionCycle: "2020 Election Cycle",
-          ElectionTitle: "District 9 Representative",
-          Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
-        },
-      ],
-    },
-  ],
+  candidates: {
+    Candidates: [
+      {
+        Name: "Lindsay Lohan",
+        Elections: [
+          {
+            ElectionCycle: "2020 Election Cycle",
+            ElectionTitle: "District 9 Representative",
+            Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
+          },
+        ],
+      },
+    ],
+  },
+  elections: {
+    ElectionCycles: [
+      {
+        Title: "2020 Election Cycle",
+        Date: "2020-11-15",
+        TotalContributions: 1000,
+        OfficeElections: [
+          {
+            Title: "District 9 Representative",
+            Candidates: ["Jake John", "Lindsay Lohan"],
+            TotalContributions: 300,
+          },
+        ],
+        Referendums: [
+          {
+            Title: "Ballot Measure C",
+            Description: "This ballot measure will allow people to have fun",
+            "Total Contributions": 700,
+          },
+        ],
+      },
+    ],
+  },
 }
 
-exports.sourceNodes = async ({
-  actions,
-  createNodeId,
-  createContentDigest,
-}) => {
-  const { createNode } = actions
-
-  let data
+async function fetchEndpoint(endpoint) {
   try {
     const response = await fetch(
-      `http://${HOSTNAME}/open-disclosure/api/v1.0/candidates`
+      `http://${HOSTNAME}/open-disclosure/api/v1.0/${endpoint}`
     )
-    data = await response.json()
+    if (response.ok) {
+      return await response.json()
+    }
   } catch (networkError) {
     console.warn(
       "Unable to reach the API server at " +
@@ -41,12 +62,22 @@ exports.sourceNodes = async ({
     console.info(
       "Use the environment variable GATSBY_API_HOST to use a different hostname for the API server"
     )
-    // Use dummy data as a fallback in case the API isn't available.
-    // TODO This is only for development purposes - get rid of this
-    data = DUMMY_DATA
   }
+  return DUMMY_DATA[endpoint]
+}
 
-  data.Candidates.forEach(candidate => {
+exports.sourceNodes = async ({
+  actions,
+  createNodeId,
+  createContentDigest,
+}) => {
+  const { createNode } = actions
+
+  const [candidateData, electionData] = await Promise.all([
+    fetchEndpoint("candidates"),
+    fetchEndpoint("elections"),
+  ])
+  candidateData.Candidates.forEach(candidate => {
     createNode({
       ...candidate,
       id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.id}`),
@@ -56,6 +87,19 @@ exports.sourceNodes = async ({
         type: CANDIDATE_NODE_TYPE,
         content: JSON.stringify(candidate),
         contentDigest: createContentDigest(candidate),
+      },
+    })
+  })
+  electionData.ElectionCycles.forEach(election => {
+    createNode({
+      ...election,
+      id: createNodeId(`${ELECTION_NODE_TYPE}-${election.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: ELECTION_NODE_TYPE,
+        content: JSON.stringify(election),
+        contentDigest: createContentDigest(election),
       },
     })
   })

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 // Libraries
 import React from "react"
+import { graphql } from "gatsby"
 // Styles
 import styles from "./index.module.scss"
 // Components
@@ -191,3 +192,37 @@ export default class MainPage extends React.PureComponent {
     )
   }
 }
+
+export const query = graphql`
+  query {
+    allCandidate {
+      edges {
+        node {
+          Name
+          Elections {
+            ElectionCycle
+            ElectionTitle
+            Committees {
+              Name
+              TotalFunding
+            }
+          }
+        }
+      }
+    }
+    allElection {
+      edges {
+        node {
+          Title
+          TotalContributions
+          OfficeElections {
+            Candidates
+            Title
+            TotalContributions
+          }
+          Date
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
I added another fetch request to our new Gatsby source plugin, so it now fetches from both `/candidates` and `/elections` and creates GraphQL nodes for the data it gets back. Also, I added an export for the GraphQL query to index.js, so this data is now available on this page through `this.props.data`. To use this data in another page, just add an export for your query:

```
export const query = graphql` ... `
```

and then Gatsby will magically hook it up so your React component receives a prop called `data` with the result.

Both of these queries, along with the mock data for them, are just hardcoded in this plugin for now. I could refactor it so that the plugin accepts the API endpoint as a param, and we just create multiple instances of the plugin to query multiple endpoints. But I'm leaving it as is for now because there's a chance I want to make some changes to how we create GraphQL nodes - we might want to actually create schemas for them and link them so you can query from candidate -> election -> candidates, etc.

I didn't add `/total-contributions` here yet because right now it just returns a single string, and it sounds like that might change? So I didn't want to create a node for that until we know what the shape will look like.
