### PR TITLE
Link Election and Candidate GraphQL nodes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-slug-field",
       options: {
-        filter: { internal: { type: "candidate" } },
+        filter: { internal: { type: "Candidate" } },
         source: "Name",
         fieldName: "slug",
       },

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -2,8 +2,8 @@ const fetch = require("node-fetch")
 
 // TODO Add dev/prod variations
 const HOSTNAME = process.env.GATSBY_API_HOST || "localhost:5000"
-const CANDIDATE_NODE_TYPE = `candidate`
-const ELECTION_NODE_TYPE = `election`
+const CANDIDATE_NODE_TYPE = `Candidate`
+const ELECTION_NODE_TYPE = `Election`
 
 const DUMMY_DATA = {
   candidates: {
@@ -104,4 +104,39 @@ exports.sourceNodes = async ({
     })
   })
   return
+}
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type Candidate implements Node {
+      id: ID!
+      Name: String
+      Elections: [CandidateElection]
+    }
+
+    type CandidateElection {
+      ElectionCycle: String
+      ElectionTitle: String
+      Committees: [Committee]
+    }
+
+    type Committee {
+      Name: String
+      TotalFunding: String
+    }
+
+    type Election implements Node {
+      Title: String!
+      Date: String 
+      TotalContributions: String 
+      OfficeElections: [OfficeElection]
+    }
+
+    type OfficeElection {
+      Candidates: [Candidate] @link(by: "Name")
+      Title: String
+      TotalContributions: String
+    }
+  `)
 }

--- a/src/pages/candidates.js
+++ b/src/pages/candidates.js
@@ -3,26 +3,36 @@ import { Link, graphql } from "gatsby"
 import React from "react"
 
 export default function Candidates({ data }) {
+  // We're only interested in data for the upcoming election.
+  const election = data.allElection.edges[0]
   return (
     <ul>
-      {data.allCandidate.edges.map(({ node }) => (
-        <li key={node.id}>
-          <Link to={"/candidate/" + node.fields.slug}>{node.Name}</Link>
-        </li>
-      ))}
+      {election.node.OfficeElections.map(({ Candidates }) =>
+        Candidates.filter(Boolean).map(candidate => (
+          <li key={candidate.id}>
+            <Link to={"/candidate/" + candidate.fields.slug}>
+              {candidate.Name}
+            </Link>
+          </li>
+        ))
+      )}
     </ul>
   )
 }
 
 export const query = graphql`
   query {
-    allCandidate {
+    allElection {
       edges {
         node {
-          id
-          Name
-          fields {
-            slug
+          OfficeElections {
+            Title
+            Candidates {
+              Name
+              fields {
+                slug
+              }
+            }
           }
         }
       }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -216,7 +216,9 @@ export const query = graphql`
           Title
           TotalContributions
           OfficeElections {
-            Candidates
+            Candidates {
+              Name
+            }
             Title
             TotalContributions
           }


### PR DESCRIPTION
Right now the Candidates page lists all the candidates it gets back from the /candidates endpoint, regardless of which election they're participating in. In order to only show candidates for the current election, and to be able to show them in the context of the actual race they're running in, it'll be better if we can get the candidate data through the /elections endpoint instead. However, that endpoint currently only give us the names of the candidates: ['Lindsay Lohan', 'Jake John'], while the /candidates endpoint provides more data (elections, committees, etc.).

This PR links the data we get from the `/candidates` endpoint with the data we get from `/elections` in GraphQL by setting up a foreign key relationship between the respective GraphQL nodes. As a result of this change, you can query GraphQL like this:

<img width="1137" alt="Screen Shot 2020-08-31 at 11 17 50 PM" src="https://user-images.githubusercontent.com/2308395/91804622-37d30780-ebe0-11ea-9785-eb980f93dbea.png">

which we'll now use in the Candidates page to get the list of candidates + the slugs for their pages (which are created magically for the Candidate node).

Notes:
* This change involved actually defining our GraphQL schema (in order to use a custom field for the foreign key) which is probably good to do anyway
* You'll notice that one of the nodes is null; if the key doesn't exist, then it just gives you null. So we'll need to make sure to filter those out/make sure the data returned from the two endpoints is consistent.

