### PR TITLE
resolving container build issue for frontend

### DIFF
--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -11,7 +11,7 @@ import { graphql, Link } from "gatsby"
 import styles from "./candidate.module.scss"
 import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
 import WebIcon from "../../static/images/web.png"
-import VotersEdgeIcon from "../../static/images/votersedge.png"
+import VotersEdgeIcon from "../../static/images/votersEdge.png"
 import TwitterIcon from "../../static/images/twitter.png"
 import ArrowIcon from "../../static/images/arrow.png"
 


### PR DESCRIPTION
error during build of front-end container due to png image import name different from actual file name

`Can't resolve '../../static/images/votersedge.png' in '/usr/src/app/open-disclosure/src/templates'

If you're trying to use a package make sure that '../../static/images/votersedge.png' is installed. If you're trying to use a local file make sure that the path is correct.

File: src/templates/candidate.js`