### PR TITLE
Make scrapper compatible with Linux

### DIFF
--- a/data_pipeline/scraper/scraper.py
+++ b/data_pipeline/scraper/scraper.py
@@ -1,5 +1,6 @@
 import os
 import time
+from os import path
 from time import sleep
 
 from selenium import webdriver
@@ -20,6 +21,8 @@ from webdriver_manager.chrome import ChromeDriverManager
 # from data_pipeline.scraper.preproccessing import PreProcessing
 from dirmanager import DirManager
 from preproccessing import PreProcessing
+
+from util import renameDownloadedFile
 
 
 class SjcWebsite:
@@ -282,6 +285,9 @@ class Scraper:
                 else:
                     # If there are forms, then we will be brought to the "forms" page.
                     self.website.verifyDownloadFormTableLoadComplete(self.driver)
+                    # Rename existing transactionExportGrid.xls to avoid overwrite
+                    if path.exists(path.join(self.download_dir, 'transactionExportGrid.xls')):
+                        renameDownloadedFile(path.join(self.download_dir, 'transactionExportGrid.xls'))
                     self.website.downloadExcel(self.driver)
 
                     self.website.clickBackButton(self.driver)

--- a/data_pipeline/scraper/util.py
+++ b/data_pipeline/scraper/util.py
@@ -1,0 +1,32 @@
+import os
+from os import path
+import logging
+import time
+from random import randint
+
+logger = logging.getLogger(__name__)
+
+
+def renameDownloadedFile(absolutefname: str):
+    '''
+    Rename a <file.ext> to <file_timestamp_randomint.ext>
+    Selenium leaves the operation system to decide the download file name if a file with the same name exists.
+    It causes transactionExportGrid.xls to be overwritten on Linux.
+    This util provide a way to force rename transactionExportGrid.xls regardless of the operation system.
+    Ref: https://stackoverflow.com/questions/34548041/selenium-give-file-name-when-downloading
+    Args:
+        absolutefname: str Absolute downloaded excel file name to be renamed
+    Returns:
+        None
+    '''
+    if not path.exists(absolutefname):
+        logger.warning("{} does not exist".format(absolutefname))
+        return
+    if not path.isfile(absolutefname):
+        logger.warning("{} is not a valid file".format(absolutefname))
+        return
+    dirname = path.dirname(absolutefname)
+    basename = path.basename(absolutefname)
+    f, ext = path.splitext(basename)
+    newfilename = "{}_{}_{}{}".format(f, int(round(time.time())), randint(0, 10), ext)
+    os.replace(absolutefname, path.join(dirname, newfilename))


### PR DESCRIPTION
Currently scrapper failed to generate aggregated_data on Linux simple because selenium overwrites transactionExportGrid.xls each download and this downloaded file naming depends on the operation system. The fix is to force renaming downloaded file name to avoid overwrite regardless of the operation system. 