### PR TITLE
Create GraphQL node for OfficeElection type and make a slug for it

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,5 +16,13 @@ module.exports = {
         fieldName: "slug",
       },
     },
+    {
+      resolve: "gatsby-plugin-slug-field",
+      options: {
+        filter: { internal: { type: "OfficeElection" } },
+        source: "Title",
+        fieldName: "slug",
+      },
+    },
   ],
 }

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -97,11 +97,6 @@ exports.sourceNodes = async ({
     })
   })
   electionData.ElectionCycles.forEach(election => {
-    const officeElections = election.OfficeElections.map(
-      officeElection => officeElection.Title
-    )
-    console.log(election.OfficeElections)
-    console.log(officeElections)
     election.OfficeElections.forEach(officeElection => {
       createNode({
         ...officeElection,
@@ -117,7 +112,11 @@ exports.sourceNodes = async ({
     })
     createNode({
       ...election,
-      OfficeElections: officeElections,
+      OfficeElections: election.OfficeElections.map(
+        // This is the field we're linking by.
+        // TODO Could we just do this all inline somehow?
+        officeElection => officeElection.Title
+      ),
       id: createNodeId(`${ELECTION_NODE_TYPE}-${election.id}`),
       parent: null,
       children: [],


### PR DESCRIPTION
In order to use our plugin to create a slug for OfficeElections, it needs to be an actual GraphQL node. Making it a node by calling createNode, and linking it to the Election node in the schema.
<img width="1039" alt="Screen Shot 2020-09-07 at 2 14 34 PM" src="https://user-images.githubusercontent.com/2308395/92417064-39875880-f115-11ea-9322-d6a5f62fa8e4.png">
