### PR TITLE
Update candidate schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,15 +44,6 @@ exports.createPages = async ({ graphql, actions }) => {
       }
     }
   `)
-  result.data.allCandidate.edges.forEach(({ node }) => {
-    createPage({
-      path: "/candidate/" + node.fields.slug,
-      component: path.resolve("src/templates/candidate.js"),
-      context: {
-        slug: node.fields.slug,
-      },
-    })
-  })
   result.data.allElection.edges.forEach(({ node }) => {
     node.OfficeElections.forEach(election => {
       createPage({
@@ -70,6 +61,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: path.resolve("src/templates/candidate.js"),
       context: {
         slug: node.fields.slug,
+        id: node.id,
       },
     })
   })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,3 +74,44 @@ exports.createPages = async ({ graphql, actions }) => {
     })
   })
 }
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type Committee {
+      Name: String
+      TotalFunding: String
+    }
+
+    type Candidate implements Node {
+      id: ID!
+      Name: String!
+      Committees: [Committee]
+    }
+
+    type CandidatesJson implements Node {
+      id: ID!
+      name: String!
+      twitter: String
+      seat: String
+      apiData: Candidate @link(by: "ID" from: "id")
+    }
+
+    type Election implements Node {
+      Title: String!
+      Date: String 
+      TotalContributions: String 
+      OfficeElections: [OfficeElection] @link(by: "Title")
+    }
+
+    type OfficeElection implements Node {
+      Candidates: [Candidate] @link(by: "Name")
+      Title: String
+      TotalContributions: String
+    }
+
+    type Metadata implements Node{
+      DateProcessed: String!
+    }
+  `)
+}

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -11,12 +11,44 @@ const DUMMY_DATA = {
   candidates: {
     Candidates: [
       {
-        Name: "Lindsay Lohan",
-        Elections: [
+        ID: "councilmember-district-6;dev-davis;11-3-2020",
+        Name: "Dev Davis",
+        Committees: [
           {
-            ElectionCycle: "2020 Election Cycle",
-            ElectionTitle: "District 9 Representative",
-            Committees: [{ Name: "Lindsay Lohan 2020", TotalFunding: 300 }],
+            ID: "john-pisacane-&-teresa-newell;11-3-2020",
+            Name: "John Pisacane & Teresa Newell",
+            TotalFunding: 500.0,
+          },
+          {
+            ID: "mina-acharya;11-3-2020",
+            Name: "Mina Acharya",
+            TotalFunding: 600.0,
+          },
+          {
+            ID: "sanjeev-acharya;11-3-2020",
+            Name: "Sanjeev Acharya",
+            TotalFunding: 600.0,
+          },
+        ],
+      },
+      {
+        ID: 'councilmember-district-6;jacob-"jake"-tonkel;11-3-2020',
+        Name: 'Jacob "Jake" Tonkel',
+        Committees: [
+          {
+            ID: "gary-abreim;11-3-2020",
+            Name: "Gary Abreim",
+            TotalFunding: 25.0,
+          },
+          {
+            ID: "blake-adams;11-3-2020",
+            Name: "Blake Adams",
+            TotalFunding: 125.0,
+          },
+          {
+            ID: "vicki-adams;11-3-2020",
+            Name: "Vicki Adams",
+            TotalFunding: 31.46,
           },
         ],
       },
@@ -86,7 +118,7 @@ exports.sourceNodes = async ({
   candidateData.Candidates.forEach(candidate => {
     createNode({
       ...candidate,
-      id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.id}`),
+      id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.ID}`),
       parent: null,
       children: [],
       internal: {
@@ -139,43 +171,4 @@ exports.sourceNodes = async ({
     },
   })
   return
-}
-
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions
-  createTypes(`
-    type Candidate implements Node {
-      id: ID!
-      Name: String
-      Elections: [CandidateElection]
-    }
-
-    type CandidateElection {
-      ElectionCycle: String
-      ElectionTitle: String
-      Committees: [Committee]
-    }
-
-    type Committee {
-      Name: String
-      TotalFunding: String
-    }
-
-    type Election implements Node {
-      Title: String!
-      Date: String 
-      TotalContributions: String 
-      OfficeElections: [OfficeElection] @link(by: "Title")
-    }
-
-    type OfficeElection implements Node {
-      Candidates: [Candidate] @link(by: "Name")
-      Title: String
-      TotalContributions: String
-    }
-
-    type Metadata implements Node{
-      DateProcessed: String!
-    }
-  `)
 }

--- a/plugins/source-api-plugin/gatsby-node.js
+++ b/plugins/source-api-plugin/gatsby-node.js
@@ -58,12 +58,12 @@ const DUMMY_DATA = {
     ElectionCycles: [
       {
         Title: "2020 Election Cycle",
-        Date: "2020-11-15",
+        Date: "2020-11-03",
         TotalContributions: 1000,
         OfficeElections: [
           {
-            Title: "District 9 Representative",
-            Candidates: ["Lindsay Lohan"],
+            Title: "Councilmember District 6",
+            Candidates: ['Jacob "Jake" Tonkel', "Dev Davis"],
             TotalContributions: 300,
           },
         ],

--- a/src/data/candidates/david-cohen.json
+++ b/src/data/candidates/david-cohen.json
@@ -1,5 +1,6 @@
 {
   "name": "David Cohen",
+  "id": "councilmember-district-4;david-cohen;11-3-2020",
   "seat": "District 4",
   "ballotDesignation": "Governing Board Member, Berryessa Union School District",
   "website": "www.electdavidcohen.com",

--- a/src/data/candidates/devora-davis.json
+++ b/src/data/candidates/devora-davis.json
@@ -1,5 +1,6 @@
 {
-  "name": "Devora \"Dev\" Davis",
+  "name": "Dev Davis",
+  "id": "councilmember-district-6;dev-davis;11-3-2020",
   "seat": "District 6",
   "ballotDesignation": "Councilwoman/Mother",
   "website": "www.devdavis.com",

--- a/src/data/candidates/jake-tonkel.json
+++ b/src/data/candidates/jake-tonkel.json
@@ -1,5 +1,6 @@
 {
-  "name": "Jake Tonkel",
+  "name": "Jacob \"Jake\" Tonkel",
+  "id": "councilmember-district-6;jacob-\"jake\"-tonkel;11-3-2020",
   "seat": "District 6",
   "ballotDesignation": "Senior Biomedical Engineer",
   "website": "www.jake4d6.com",

--- a/src/data/candidates/lan-diep.json
+++ b/src/data/candidates/lan-diep.json
@@ -1,5 +1,6 @@
 {
   "name": "Lan Diep",
+  "id": "councilmember-district-4;lan-diep;11-3-2020",
   "seat": "District 4",
   "ballotDesignation": "City Councilmember",
   "website": "www.lanforsanjose.com",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -59,7 +59,7 @@ export default function MainPage(props) {
     election.Candidates.forEach(candidate => {
       if (candidate) {
         let funding = 0
-        candidate.Elections[0].Committees.forEach(committee => {
+        candidate.Committees.forEach(committee => {
           funding += parseInt(committee.TotalFunding)
         })
         candidateList.push({
@@ -207,13 +207,9 @@ export const query = graphql`
             }
             Candidates {
               Name
-              Elections {
-                ElectionCycle
-                ElectionTitle
-                Committees {
-                  Name
-                  TotalFunding
-                }
+              Committees {
+                Name
+                TotalFunding
               }
               fields {
                 slug

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -55,6 +55,7 @@ export default function Candidate({ data }) {
     ballotDesignation,
     website,
     twitter,
+    apiData,
   } = data.candidatesJson
   return (
     <Layout windowIsLarge={useWindowIsLarge()}>
@@ -117,7 +118,7 @@ export default function Candidate({ data }) {
                 </div>
               </div>
             </section>
-            {data.Candidate == null ? (
+            {apiData == null ? (
               <NoData page="candidate" />
             ) : (
               <>
@@ -161,7 +162,7 @@ export default function Candidate({ data }) {
                 />
                 <section>
                   <SectionHeader title="Other committees controlled by candidate" />
-                  {data.Candidate.Elections[0].Committees.map(({ Name }) => (
+                  {apiData.Committees.map(({ Name }) => (
                     <Link className={styles.committeeLink}>{Name}</Link>
                   ))}
                 </section>
@@ -176,21 +177,18 @@ export default function Candidate({ data }) {
 
 export const query = graphql`
   query($slug: String!) {
-    candidate(fields: { slug: { eq: $slug } }) {
-      Name
-      Elections {
-        ElectionTitle
-        Committees {
-          Name
-        }
-      }
-    }
     candidatesJson(fields: { slug: { eq: $slug } }) {
       name
       seat
       ballotDesignation
       website
       twitter
+      apiData {
+        Committees {
+          Name
+          TotalFunding
+        }
+      }
     }
   }
 `

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -176,8 +176,8 @@ export default function Candidate({ data }) {
 }
 
 export const query = graphql`
-  query($slug: String!) {
-    candidatesJson(fields: { slug: { eq: $slug } }) {
+  query($id: String) {
+    candidatesJson(id: { eq: $id }) {
       name
       seat
       ballotDesignation


### PR DESCRIPTION
In this PR:
- Update the mock data for Candidates to match what's now being returned from the API. The biggest change is lifting the 'Committees' field to be directly exposed on the Candidate node (now you can do candidate.Committees instead of candidate.elections.forEach(election => election.Committees)
- Move the GraphQL schema customization out of the plugin and into our main gatsby-node.js, so that I can link from the JSON node to the api node. Now you can do: candidateJson.apiData.Committees
- Update the JSON files to add the ID field and standardize the names, since those are still used for the page slugs (will update that later)