### PR TITLE
Create measure pages using JSON data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -38,5 +38,13 @@ module.exports = {
         fieldName: "slug",
       },
     },
+    {
+      resolve: "gatsby-plugin-slug-field",
+      options: {
+        filter: { internal: { type: "MeasuresJson" } },
+        source: "name",
+        fieldName: "slug",
+      },
+    },
   ],
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -149,8 +149,8 @@ exports.sourceNodes = async ({
           children: [],
           internal: {
             type: OFFICE_ELECTION_NODE_TYPE,
-            content: JSON.stringify(election),
-            contentDigest: createContentDigest(election),
+            content: JSON.stringify(officeElection),
+            contentDigest: createContentDigest(officeElection),
           },
         })
         return id
@@ -220,6 +220,18 @@ exports.createPages = async ({ graphql, actions }) => {
           }
         }
       }
+      allMeasuresJson {
+        edges {
+          node {
+            id
+            electionDate
+            name
+            fields {
+              slug
+            }
+          }
+        }
+      }
     }
   `)
   result.data.allElection.edges.forEach(({ node }) => {
@@ -240,6 +252,16 @@ exports.createPages = async ({ graphql, actions }) => {
       context: {
         slug: node.fields.slug,
         id: node.id,
+      },
+    })
+  })
+  result.data.allMeasuresJson.edges.forEach(({ node }) => {
+    createPage({
+      path: `/${node.electionDate}/referendum/${node.fields.slug}`,
+      component: path.resolve("src/templates/measure.js"),
+      context: {
+        id: node.id,
+        slug: node.fields.slug,
       },
     })
   })
@@ -266,6 +288,13 @@ exports.createSchemaCustomization = ({ actions }) => {
       twitter: String
       seat: String
       apiData: Candidate @link(by: "ID" from: "id")
+    }
+
+    type MeasuresJson implements Node {
+      electionDate: String!
+      title: String!
+      description: String!
+      ballotLanguage: String!
     }
 
     type Election implements Node {

--- a/src/data/measures/measure-g.json
+++ b/src/data/measures/measure-g.json
@@ -1,0 +1,6 @@
+{
+  "electionDate": "2020-11-03",
+  "name": "Measure G",
+  "description": "Charter Amendment regarding Independent Police Auditor, Planning Commission, Redistricting",
+  "ballotLanguage": "Shall the City Charter be amended to: expand the Independent Police Auditor’s oversight, including review of officer-involved shootings and use of force incidents causing death or great bodily injury, review of department-initiated investigations against officers, and other technical amendments; increase the Planning Commission to 11 members with Council appointing one member from each Council District and one “at-large” member; and allow the Council to establish timelines for redistricting when Census results are late?"
+}

--- a/src/data/measures/measure-h.json
+++ b/src/data/measures/measure-h.json
@@ -1,0 +1,6 @@
+{
+  "electionDate": "2020-11-03",
+  "name": "Measure H",
+  "description": "Cardroom Tax",
+  "ballotLanguage": "To fund general San Jose services, including fire protection, disaster preparedness, 911 emergency response, street repair, youth programs, addressing homelessness, and supporting vulnerable residents, shall an ordinance be adopted increasing the cardroom tax rate from 15% to 16.5%, applying the tax to third party providers at these rates: up to $25,000,000 at 5%; $25,000,001 to $30,000,000 at 7.5%; and over $30,000,000 at 10%, increasing card tables by 30, generating approximately $15,000,000 annually, until repealed?"
+}

--- a/src/templates/measure.js
+++ b/src/templates/measure.js
@@ -1,0 +1,23 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+export default function Measure({ data }) {
+  const { name, ballotLanguage } = data.measuresJson
+  return (
+    <div>
+      <header>
+        <h1>{name}</h1>
+      </header>
+      <p>{ballotLanguage}</p>
+    </div>
+  )
+}
+
+export const query = graphql`
+  query($id: String) {
+    measuresJson(id: { eq: $id }) {
+      name
+      ballotLanguage
+    }
+  }
+`


### PR DESCRIPTION
Initially I was going to sync the referendums schema from the API, but it sounds like none of the measures actually have any funding data. So instead of hooking this up to the API, let's just create JSON files for each measure in the election (there are only two, it seems) and use those to create and render the measure pages.

It looks like the measure pages PR isn't merged yet, so I'm just creating a placeholder `measure.js` in /templates for now.