### PR TITLE
Include election date + office title in candidate page path

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -194,28 +194,13 @@ exports.createPages = async ({ graphql, actions }) => {
               fields {
                 slug
               }
-            }
-          }
-        }
-      }
-      allCandidate {
-        edges {
-          node {
-            id
-            Name
-            fields {
-              slug
-            }
-          }
-        }
-      }
-      allCandidatesJson {
-        edges {
-          node {
-            id
-            name
-            fields {
-              slug
+              Candidates {
+                ID
+                Name
+                fields {
+                  slug
+                }
+              }
             }
           }
         }
@@ -237,22 +222,22 @@ exports.createPages = async ({ graphql, actions }) => {
   result.data.allElection.edges.forEach(({ node }) => {
     node.OfficeElections.forEach(election => {
       createPage({
-        path: "/" + node.Date + "/candidates/" + election.fields.slug,
+        path: `/${node.Date}/candidates/${election.fields.slug}`,
         component: path.resolve("src/templates/candidates.js"),
         context: {
           slug: election.fields.slug,
         },
       })
-    })
-  })
-  result.data.allCandidatesJson.edges.forEach(({ node }) => {
-    createPage({
-      path: "/candidate/" + node.fields.slug,
-      component: path.resolve("src/templates/candidate.js"),
-      context: {
-        slug: node.fields.slug,
-        id: node.id,
-      },
+      election.Candidates.forEach(candidate => {
+        createPage({
+          path: `/${node.Date}/candidate/${election.fields.slug}/${candidate.fields.slug}`,
+          component: path.resolve("src/templates/candidate.js"),
+          context: {
+            slug: candidate.fields.slug,
+            id: candidate.ID,
+          },
+        })
+      })
     })
   })
   result.data.allMeasuresJson.edges.forEach(({ node }) => {
@@ -280,6 +265,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       ID: String!
       Name: String!
       Committees: [Committee]
+      jsonNode: CandidatesJson @link(by: "id" from: "ID")
     }
 
     type CandidatesJson implements Node {
@@ -287,7 +273,9 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String!
       twitter: String
       seat: String
-      apiData: Candidate @link(by: "ID" from: "id")
+      ballotDesignation: String
+      website: String
+      apiNode: Candidate @link(by: "ID" from: "id")
     }
 
     type MeasuresJson implements Node {

--- a/src/components/candidatesListItem.js
+++ b/src/components/candidatesListItem.js
@@ -9,10 +9,10 @@ function formatPercent(value) {
   return percentFormatter.format(value)
 }
 
-export default ({ Name, fields: { slug } }) => {
+export default ({ Name, path }) => {
   const percent = formatPercent(83455 / 123456)
   return (
-    <Link className={styles.container} to={"/candidate/" + slug}>
+    <Link className={styles.container} to={path}>
       <img
         height="12.5rem"
         width="12.5rem"

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -48,30 +48,24 @@ function ChartSection({ id, title, type, total, data, ...passProps }) {
 }
 
 export default function Candidate({ data }) {
-  const {
-    name,
-    seat,
-    ballotDesignation,
-    website,
-    twitter,
-    apiData,
-  } = data.candidatesJson
+  const { Name, jsonNode } = data.candidate
+  const { seat, ballotDesignation, website, twitter } = jsonNode
   return (
     <Layout windowIsLarge={useWindowIsLarge()}>
       <SideNav
-        candidate
+        candidate={true}
         headerBackground="blue"
-        pageTitle={name}
+        pageTitle={Name}
         pageSubtitle={seat}
       >
         <div className={styles.mainSection}>
           <section>
-            <SectionHeader title={name} />
+            <SectionHeader title={Name} />
             <div className={styles.aboutSection}>
               <img
                 className={styles.profilePhoto}
                 src="https://picsum.photos/125"
-                alt={`Headshot of candidate ${name}`}
+                alt={`Headshot of candidate ${Name}`}
               />
               <div>
                 <p className={styles.aboutTitle}>
@@ -116,7 +110,7 @@ export default function Candidate({ data }) {
               </div>
             </div>
           </section>
-          {apiData == null ? (
+          {data.candidate.Committees == null ? (
             <NoData page="candidate" />
           ) : (
             <>
@@ -160,7 +154,7 @@ export default function Candidate({ data }) {
               />
               <section>
                 <SectionHeader title="Other committees controlled by candidate" />
-                {apiData.Committees.map(({ Name }) => (
+                {data.candidate.Committees.map(({ Name }) => (
                   <Link className={styles.committeeLink}>{Name}</Link>
                 ))}
               </section>
@@ -174,17 +168,18 @@ export default function Candidate({ data }) {
 
 export const query = graphql`
   query($id: String) {
-    candidatesJson(id: { eq: $id }) {
-      name
-      seat
-      ballotDesignation
-      website
-      twitter
-      apiData {
-        Committees {
-          Name
-          TotalFunding
-        }
+    candidate(ID: { eq: $id }) {
+      Name
+      Committees {
+        Name
+        TotalFunding
+      }
+      jsonNode {
+        name
+        seat
+        ballotDesignation
+        website
+        twitter
       }
     }
   }

--- a/src/templates/candidates.js
+++ b/src/templates/candidates.js
@@ -8,7 +8,6 @@ import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
 
 export default function Candidates({ data }) {
   const election = data.allElection.edges[0].node
-  // Should link to /{node.Date}/candidate/${candidateName}}
   return (
     <div className={styles.outerContainer}>
       <Layout windowIsLarge={useWindowIsLarge()}>
@@ -18,13 +17,15 @@ export default function Candidates({ data }) {
             pageSubtitle="City of San José Candidates"
           >
             <div className={styles.candidateList}>
-              {election.OfficeElections.map(({ Candidates }) =>
-                Candidates.filter(Boolean).map(candidate => (
-                  <CandidatesListItem
-                    key={candidate.fields.slug}
-                    {...candidate}
-                  />
-                ))
+              {election.OfficeElections.map(
+                ({ Candidates, fields: { slug } }) =>
+                  Candidates.filter(Boolean).map(candidate => (
+                    <CandidatesListItem
+                      path={`/${election.Date}/candidate/${slug}/${candidate.fields.slug}`}
+                      key={candidate.fields.slug}
+                      {...candidate}
+                    />
+                  ))
               )}
             </div>
           </SideNav>
@@ -39,6 +40,7 @@ export const query = graphql`
     allElection {
       edges {
         node {
+          Date
           OfficeElections {
             Title
             TotalContributions


### PR DESCRIPTION
Making some changes to how we create pages to make it easier to include the election date and office title in the path of the candidate page URL. So instead of being:

  /candidate/lan-diep

it will now be:

  /2020-11-03/candidate/district-4-representative/lan-diep

Also, making some changes to how we access candidate data in GraphQL. We can now link both ways from JSON data <-> API data (before it was just JSON -> API). On the candidate page, instead of fetching the JSON node and linking to the API node, I'm doing the reverse. This lines up a little better with what we're doing in the rest of the site. This doesn't really have any effect on anything, I'm just doing it to be more consistent.