### PR TITLE
Query specific office election from candidates pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -214,6 +214,7 @@ exports.createPages = async ({ graphql, actions }) => {
             Date
             TotalContributions
             OfficeElections {
+              id
               Title
               TotalContributions
               fields {
@@ -247,6 +248,8 @@ exports.createPages = async ({ graphql, actions }) => {
         component: path.resolve("src/templates/candidates.js"),
         context: {
           slug: election.fields.slug,
+          officeElectionID: election.id,
+          electionDate: node.Date,
         },
       })
       election.Candidates.forEach(candidate => {

--- a/src/templates/candidates.js
+++ b/src/templates/candidates.js
@@ -7,14 +7,9 @@ import CandidatesListItem from "../components/candidatesListItem"
 import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
 import SectionHeader from "../components/sectionHeader"
 
-export default function Candidates({ data }) {
-  const election = data.allElection.edges[0].node
-  let selectedElection = window.location.href.split("/")
-  selectedElection = selectedElection[selectedElection.length - 1]
-    .split("-")
-    .map(word => word[0].toUpperCase() + word.slice(1))
-    .join(" ")
-
+export default function Candidates({ data, pageContext }) {
+  const { electionDate } = pageContext
+  const { officeElection } = data
   return (
     <div className={styles.outerContainer}>
       <Layout windowIsLarge={useWindowIsLarge()}>
@@ -24,18 +19,15 @@ export default function Candidates({ data }) {
             pageSubtitle="City of San José Candidates"
           >
             <div className={styles.candidateList}>
-              <SectionHeader title={selectedElection} />
-              {election.OfficeElections.map(
-                ({ Candidates, TotalContributions, fields: { slug } }) =>
-                  Candidates.map(candidate => (
-                    <CandidatesListItem
-                      path={`/${election.Date}/candidate/${slug}/${candidate.fields.slug}`}
-                      key={candidate.fields.slug}
-                      electionTotal={TotalContributions}
-                      {...candidate}
-                    />
-                  ))
-              )}
+              <SectionHeader title={officeElection.Title} />
+              {officeElection.Candidates.map(candidate => (
+                <CandidatesListItem
+                  path={`/${electionDate}/candidate/${officeElection.fields.slug}/${candidate.fields.slug}`}
+                  key={candidate.fields.slug}
+                  electionTotal={officeElection.TotalContributions}
+                  {...candidate}
+                />
+              ))}
             </div>
           </SideNav>
         </div>
@@ -45,30 +37,24 @@ export default function Candidates({ data }) {
 }
 
 export const query = graphql`
-  query {
-    allElection {
-      edges {
-        node {
-          Date
-          OfficeElections {
-            Title
-            TotalContributions
-            Candidates {
-              id
-              Name
-              TotalContributions
-              fields {
-                slug
-              }
-              jsonNode {
-                ballotDesignation
-              }
-            }
-            fields {
-              slug
-            }
-          }
+  query($officeElectionID: String) {
+    officeElection(id: { eq: $officeElectionID }) {
+      id
+      Title
+      TotalContributions
+      Candidates {
+        id
+        Name
+        TotalContributions
+        fields {
+          slug
         }
+        jsonNode {
+          ballotDesignation
+        }
+      }
+      fields {
+        slug
       }
     }
   }


### PR DESCRIPTION
Right now we query allElections on the candidates page and iterate over all the office elections and candidates, which means that we show all four candidates regardless of which race is selected. This PR passes in the officeElectionID to the candidates page and uses that to query only the specific officeElection.

<img width="1408" alt="Screen Shot 2020-09-24 at 9 19 55 PM" src="https://user-images.githubusercontent.com/2308395/94226262-08947b00-feac-11ea-8973-af87a8eb5f5a.png">
