### PR TITLE
Update the candidate cards on the index page

### DIFF
--- a/src/common/util/formatters.js
+++ b/src/common/util/formatters.js
@@ -1,0 +1,26 @@
+const percentFormatter = Intl.NumberFormat("en-US", { style: "percent" })
+
+const currencyFormatter = Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+})
+
+const thousandsFormatter = Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+})
+
+export function formatPercent(value) {
+  return percentFormatter.format(value)
+}
+
+export function formatDollars(value) {
+  return currencyFormatter.format(value)
+}
+
+export function formatDollarsInThousands(value) {
+  return thousandsFormatter.format(value)
+}

--- a/src/components/barChart.js
+++ b/src/components/barChart.js
@@ -1,21 +1,11 @@
+import {
+  formatDollarsInThousands,
+  formatPercent,
+} from "../common/util/formatters"
+
+import Bar from "./bar"
 import React from "react"
 import styles from "./barChart.module.scss"
-import Bar from "./bar"
-
-const percentFormatter = Intl.NumberFormat("en-US", { style: "percent" })
-const thousandsFormatter = Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  notation: "compact",
-})
-
-function formatPercent(value) {
-  return percentFormatter.format(value)
-}
-
-function formatDollarsInThousands(value) {
-  return thousandsFormatter.format(value)
-}
 
 function Row({ label, value, total, type, showPercentages, isCommittee }) {
   const percent = formatPercent(value / total)

--- a/src/components/candidateItem.js
+++ b/src/components/candidateItem.js
@@ -1,6 +1,6 @@
 import { Link } from "gatsby"
 import React from "react"
-import { formatDollarsInThousands } from "../common/util/formatters"
+import { formatDollars } from "../common/util/formatters"
 import styles from "./candidateItem.module.scss"
 
 const CandidateItem = item => (
@@ -10,7 +10,7 @@ const CandidateItem = item => (
       <div className={styles.candidateInfo}>
         <h4>{item.name}</h4>
         <p>{item.position}</p>
-        <h3>{formatDollarsInThousands(item.amount)}</h3>
+        <h3>{formatDollars(item.amount)}</h3>
         <p className={styles.amountRaised}>Amount raised</p>
       </div>
     </Link>

--- a/src/components/candidateItem.js
+++ b/src/components/candidateItem.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { formatDollarsInThousands } from "../common/util/formatters"
 import styles from "./candidateItem.module.scss"
 
 const CandidateItem = item => (
@@ -7,13 +8,7 @@ const CandidateItem = item => (
     <div className={styles.candidateInfo}>
       <h4>{item.name}</h4>
       <p>{item.position}</p>
-      <h3>
-        {item.amount.toLocaleString("en-US", {
-          style: "currency",
-          currency: "USD",
-          maximumSignificantDigits: 3,
-        })}
-      </h3>
+      <h3>{formatDollarsInThousands(item.amount)}</h3>
       <p className={styles.amountRaised}>Amount raised</p>
     </div>
   </div>

--- a/src/components/candidateItem.js
+++ b/src/components/candidateItem.js
@@ -1,3 +1,4 @@
+import { Link } from "gatsby"
 import React from "react"
 import { formatDollarsInThousands } from "../common/util/formatters"
 import styles from "./candidateItem.module.scss"
@@ -5,12 +6,14 @@ import styles from "./candidateItem.module.scss"
 const CandidateItem = item => (
   <div className={styles.container} key={item.name}>
     <img alt="candidate" height="180px" width="180px" src={item.image} />
-    <div className={styles.candidateInfo}>
-      <h4>{item.name}</h4>
-      <p>{item.position}</p>
-      <h3>{formatDollarsInThousands(item.amount)}</h3>
-      <p className={styles.amountRaised}>Amount raised</p>
-    </div>
+    <Link to={item.href}>
+      <div className={styles.candidateInfo}>
+        <h4>{item.name}</h4>
+        <p>{item.position}</p>
+        <h3>{formatDollarsInThousands(item.amount)}</h3>
+        <p className={styles.amountRaised}>Amount raised</p>
+      </div>
+    </Link>
   </div>
 )
 

--- a/src/components/candidateItem.module.scss
+++ b/src/components/candidateItem.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   display: flex;
+  min-width: 36rem;
   flex-direction: column;
   background-color: transparent;
   margin: 4rem 1.5rem 4rem;
@@ -21,7 +22,7 @@
     background-color: $primaryWhite;
     border-radius: 4px;
     margin-top: -9rem;
-    padding: 10rem 10rem 4rem;
+    padding: 10rem 1rem 4rem;
     text-align: center;
     z-index: 1;
 
@@ -29,6 +30,7 @@
     h4,
     p {
       font-family: "Lato";
+      max-width: 34rem;
     }
 
     h4 {

--- a/src/components/candidatesListItem.js
+++ b/src/components/candidatesListItem.js
@@ -1,24 +1,9 @@
-import React from "react"
-import { Link } from "gatsby"
+import { formatDollars, formatPercent } from "../common/util/formatters"
+
 import Bar from "./bar"
+import { Link } from "gatsby"
+import React from "react"
 import styles from "./candidatesListItem.module.scss"
-
-const percentFormatter = Intl.NumberFormat("en-US", { style: "percent" })
-
-function formatPercent(value) {
-  return percentFormatter.format(value)
-}
-
-const currencyFormatter = Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-})
-
-function formatDollars(value) {
-  return currencyFormatter.format(value)
-}
 
 export default ({
   Name,

--- a/src/components/totalAmountItem.js
+++ b/src/components/totalAmountItem.js
@@ -1,51 +1,41 @@
 import React from "react"
+import { formatDollars } from "../common/util/formatters"
 import styles from "./totalAmountItem.module.scss"
-
-const currencyFormatter = Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-})
-
-function formatDollars(value) {
-  return currencyFormatter.format(value)
-}
 
 function title(type) {
   switch (type) {
     case "expenditures":
-      return "Total spent";
+      return "Total spent"
     case "balance":
-      return "Current balance";
+      return "Current balance"
     case "measureSupport":
-      return "Total Raised to Support";
+      return "Total Raised to Support"
     case "measureOppose":
-      return "Total Raised to Oppose";
+      return "Total Raised to Oppose"
     default:
-      return "Total raised";
+      return "Total raised"
   }
 }
 
 function detail(type) {
-  let detail;
+  let detail
 
   switch (type) {
     case "expenditures":
-      detail = "Expenditures";
-      break;
+      detail = "Expenditures"
+      break
     case "balance":
-      detail = "Cash on hand";
-      break;
+      detail = "Cash on hand"
+      break
     case "measureSupport":
     case "measureOppose":
-      break;
+      break
     default:
-      detail = "Contributions";
-      break;
+      detail = "Contributions"
+      break
   }
 
-  return detail ? " (" + detail + ")" : "";
+  return detail ? " (" + detail + ")" : ""
 }
 
 export default function TotalAmountItem({ total, type = "contributions" }) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ export default function MainPage(props) {
     props.data.allMetadata.edges[0].node.DateProcessed
   )
   let candidatesRunning = 0
-  const candidateList = []
+  let candidateList = []
   currentElection.OfficeElections.forEach(election => {
     candidatesRunning += election.Candidates.length
     election.Candidates.forEach(candidate => {
@@ -67,6 +67,13 @@ export default function MainPage(props) {
       }
     })
   })
+  candidateList = candidateList.sort(
+    (candidate1, candidate2) => candidate2.amount - candidate1.amount
+  )
+
+  if (candidateList.length > 3) {
+    candidateList = candidateList.slice(0, 3)
+  }
 
   const candidatesPageLink = `/${currentElection.Date}/candidates/${currentElection.OfficeElections[0].fields.slug}`
   const referendumsPageLink = `/${currentElection.Date}/referendums/${currentElection.Referendums[0].fields.slug}`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,7 +48,6 @@ const vote = {
 export default function MainPage(props) {
   const windowIsLarge = useWindowIsLarge()
   const currentElection = props.data.allElection.edges[0].node
-  console.log(props.data.allElection)
   const lastScrape = new Date(
     props.data.allMetadata.edges[0].node.DateProcessed
   )
@@ -58,14 +57,10 @@ export default function MainPage(props) {
     candidatesRunning += election.Candidates.length
     election.Candidates.forEach(candidate => {
       if (candidate) {
-        let funding = 0
-        candidate.Committees.forEach(committee => {
-          funding += parseInt(committee.TotalFunding)
-        })
         candidateList.push({
           name: candidate.Name,
           position: election.Title,
-          amount: funding,
+          amount: candidate.TotalFunding,
           image: "https://picsum.photos/180",
         })
       }
@@ -209,10 +204,7 @@ export const query = graphql`
             }
             Candidates {
               Name
-              Committees {
-                Name
-                TotalFunding
-              }
+              TotalFunding
               fields {
                 slug
               }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -62,6 +62,7 @@ export default function MainPage(props) {
           position: election.Title,
           amount: candidate.TotalFunding,
           image: "https://picsum.photos/180",
+          href: `/${currentElection.Date}/candidate/${election.fields.slug}/${candidate.fields.slug}`,
         })
       }
     })


### PR DESCRIPTION
- Hook them up to the correct funding field from the API (now that it exists)
- With four of them + real (large) funding numbers, they don't really fit on the screen anymore. Switching them to use shorter currency notation ('$100K' instead of '$100,000')
- Hooking them up to the candidate pages so you can click on them