### PR TITLE
Update funding by region to include SJ

### DIFF
--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -40,7 +40,6 @@ export default function Candidate({ data }) {
   } = jsonNode
 
   const balance = TotalContributions - TotalEXPN
-  const outOfStateFunding = TotalContributions - FundingByGeo.CA
 
   return (
     <Layout windowIsLarge={useWindowIsLarge()}>
@@ -167,8 +166,12 @@ export default function Candidate({ data }) {
                   id="balance"
                   total={TotalContributions}
                   data={[
-                    { label: "Within California", value: FundingByGeo.CA },
-                    { label: "Out of state", value: outOfStateFunding },
+                    { label: "Within San José", value: FundingByGeo.SJ },
+                    {
+                      label: "Within California",
+                      value: FundingByGeo.CA - FundingByGeo.SJ, // excluding San José
+                    },
+                    { label: "Out of state", value: FundingByGeo.NonCA },
                   ]}
                   showPercentages
                 />
@@ -204,6 +207,8 @@ export const query = graphql`
       }
       FundingByGeo {
         CA
+        NonCA
+        SJ
       }
       ExpenditureByType {
         SAL


### PR DESCRIPTION
This chart now has 3 rows: % raised from within SJ, % raised from *the rest of* California (not including SJ), and % raised out-of-state. I excluded SJ from the California row because that seemed to make the most sense with the mocks (otherwise the values add up to >100%). But I think the UX could be a little clearer - should we change the label to 'the rest of California' or something like that?

<img width="968" alt="Screen Shot 2020-09-27 at 1 25 57 PM" src="https://user-images.githubusercontent.com/2308395/94375065-bfb80e80-00c5-11eb-9194-f0ad7bff0157.png">
