### PR TITLE
Add tooltips for expenditure/contributor codes, show all expenditure types

### DIFF
--- a/src/common/util/codes.js
+++ b/src/common/util/codes.js
@@ -1,38 +1,155 @@
 module.exports = {
   ContributorCodes: {
-    IND: "Individual",
-    COM: "Committee",
-    OTH: "Other",
-    PTY: "Political party",
-    SCC: "Small Contributor Committee",
+    IND: {
+      label: "Individual",
+      tooltip: "Contributions from any individual’s personal funds.",
+    },
+    COM: {
+      label: "Committee",
+      tooltip:
+        "Contributions from other committees that receive contributions. These committees will have an identification number assigned by the Secretary of State. Examples: political action committees, other candidates’ committees.",
+    },
+    OTH: {
+      label: "Other",
+      tooltip: "Business entities and other contributors.",
+    },
+    PTY: {
+      label: "Political party",
+      tooltip:
+        "contributions from political parties (including state and county central committees).",
+    },
+    SCC: {
+      label: "Small Contributor Committee",
+      tooltip:
+        "contributions from small contributor committees (applicable only to state candidates and committees).",
+    },
   },
   ExpenditureCodes: {
-    CMP: "Campaign paraphernalia/misc",
-    CNS: "Campaign consultants",
-    CTB: "Contribution",
-    CVC: "Civic donations",
-    FIL: "Candidate filing/ballot fees",
-    FND: "Fundraising events",
-    IND: "Independent expenditure supporting/opposing others",
-    LEG: "Legal defense",
-    LIT: "Campaign literature and mailings",
-    MBR: "Member communications",
-    MTG: "Meetings and appearances",
-    OFC: "Office expenses",
-    PET: "Petition circulating",
-    PHO: "Phone banks",
-    POL: "Polling and survey research",
-    POS: "Postage, delivery and messenger services",
-    PRO: "Professional services (legal, accounting)",
-    PRT: "Print ads",
-    RAD: "Radio airtime and production costs",
-    RFD: "Returned contributions",
-    SAL: "Campaign workers’ salaries",
-    TEL: "TV or cable airtime and production costs",
-    TRC: "Candidate travel, lodging, and meals",
-    TRS: "Staff/spouse travel, lodging, and meals",
-    TSF: "Transfer between committees of the same candidate/sponsor",
-    VOT: "Voter registration",
-    WEB: "Information technology costs (internet, e-mail)",
+    CMP: {
+      label: "Campaign paraphernalia",
+      tooltip:
+        "Lawn signs, buttons, bumper stickers, T-shirts, potholders, etc. Includes costs of election night event.",
+    },
+    CNS: {
+      label: "Consultants",
+      tooltip:
+        "Fees and commissions paid to professional campaign management or consulting firms.",
+    },
+    CTB: {
+      label: "Contribution",
+      tooltip: "Contributions made to other candidates and committees.",
+    },
+    CVC: {
+      label: "Civic donations",
+      tooltip:
+        "Donations to civic, nonprofit or education organizations; payments for community events.",
+    },
+    FIL: {
+      label: "Filing fees",
+      tooltip:
+        "Payments to election officials for candidate filing fees and fees charged for publication of a ballot statement.",
+    },
+    FND: {
+      label: "Fundraising",
+      tooltip:
+        "Expenditures associated with holding a fundraising event, including payments for event space to hotels or halls, payments for food and beverages to restaurants, caterers and other vendors, and payments for speakers, entertainment, and decorations. Includes costs of house parties.",
+    },
+    IND: {
+      label: "Independent expenditures",
+      tooltip:
+        "Payments for communications that support/oppose other candidates or measures that are not made in consultation or coordination with the candidates or a ballot measure committee.",
+    },
+    LEG: {
+      label: "Legal defense",
+      tooltip: "Attorney or other fees paid for legal defense.",
+    },
+    LIT: {
+      label: "Campaign literature",
+      tooltip:
+        "Preparation, production, and distribution of campaign literature, direct mail pieces, fundraising solicitations, and door hangers. Includes costs of mailing lists, design/graphics, copy and layout, printing and photocopying. Includes payments to be on a slate mailer, and for absentee ballot mailers.",
+    },
+    MBR: {
+      label: "Member communications",
+      tooltip:
+        "Payments for communications to members, employees, or shareholders of an organization, or their family members, for the purpose of supporting or opposing a candidate or ballot measure.",
+    },
+    MTG: {
+      label: "Meetings and appearances",
+      tooltip:
+        "Costs associated with meetings, press conferences, town halls, constituent meetings, etc.",
+    },
+    OFC: {
+      label: "Office expenses",
+      tooltip:
+        "Expenditures for office rent; utilities (including cellular phone service); purchase or rental of office equipment (computer, fax, photocopier, etc.) and furniture; office supplies, etc.",
+    },
+    PET: {
+      label: "Petitions",
+      tooltip:
+        "Includes payments for printing petitions and payments to signature gathering firms for ballot measure qualification drives.",
+    },
+    PHO: {
+      label: "Phone banks",
+      tooltip: "Costs of phone banks",
+    },
+    POL: {
+      label: "Polling",
+      tooltip:
+        "Polling and survey research. Costs of designing and conducting polls, reports on election trends, voter surveys, etc.",
+    },
+    POS: {
+      label: "Postage",
+      tooltip:
+        "Postal, delivery and messenger services. Includes U.S. Postal Service, Federal Express, United Parcel Service, and other delivery and courier services.",
+    },
+    PRO: {
+      label: "Professional services",
+      tooltip: "Includes legal, accounting, and bookkeeping services.",
+    },
+    PRT: {
+      label: "Print ads",
+      tooltip:
+        "Includes advertising space in newspapers, magazines and other publications, and billboard ads.",
+    },
+    RAD: {
+      label: "Radio",
+      tooltip: "Radio airtime and production costs",
+    },
+    RFD: {
+      label: "Returned contributions",
+      tooltip: "Returned contributions",
+    },
+    SAL: {
+      label: "Salaries",
+      tooltip:
+        "Campaign workers’ salaries. Includes state and federal payroll taxes.",
+    },
+    TEL: {
+      label: "TV",
+      tooltip: "Television or cable airtime and video production costs",
+    },
+    TRC: {
+      label: "Travel (Candidate)",
+      tooltip:
+        "Payments or reimbursements for travel, lodging, and meals of a candidate.",
+    },
+    TRS: {
+      label: "Travel (Staff/Spouse)",
+      tooltip:
+        "Payments or reimbursements for travel, lodging, and meals of a candidate’s representative (staff), or member of the candidate’s household.",
+    },
+    TSF: {
+      label: "Transfer",
+      tooltip: "Transfer between committees of the same candidate/sponsor",
+    },
+    VOT: {
+      label: "Voter registration",
+      tooltip: "Voter registration costs.",
+    },
+    WEB: {
+      label: "IT",
+      tooltip:
+        "Information technology costs. Includes payments for website design, e-mail, internet access, production of website and e-mail advertising.",
+    },
   },
 }

--- a/src/components/barChart.js
+++ b/src/components/barChart.js
@@ -7,12 +7,22 @@ import Bar from "./bar"
 import React from "react"
 import styles from "./barChart.module.scss"
 
-function Row({ label, value, total, type, showPercentages, isCommittee }) {
+function Row({
+  label,
+  value,
+  tooltip,
+  total,
+  type,
+  showPercentages,
+  isCommittee,
+}) {
   const percent = formatPercent(value / total)
   return (
     <div className={`${styles.row} ${isCommittee && styles.noLabel}`}>
       <div className={styles.rowTop}>
-        <p className={styles.label}>{label}</p>
+        <p className={styles.label} title={tooltip ?? label}>
+          {label}
+        </p>
         <p className={styles.value}>
           {showPercentages ? percent : formatDollarsInThousands(value)}
         </p>
@@ -32,13 +42,13 @@ function Row({ label, value, total, type, showPercentages, isCommittee }) {
 export default function BarChart({
   type = "contributions", // "contributions" | "expenditures"
   total, // number
-  rows, // Array<{label: string, value: number}>
+  rows, // Array<{label: string, value: number, tooltip?: string}>
   showPercentages = false, // Show percentages instead of dollar values
   isCommittee = false, // Removes label to the left of row, places it above
 }) {
   return (
     <div className={styles.chart}>
-      {rows.map(({ label, title, value }) => (
+      {rows.map(({ label, value, tooltip }) => (
         <>
           {isCommittee && <h4>***TO REMOVE: PLACEHOLDER COMMITTEE NAME***</h4>}
           <Row
@@ -49,6 +59,7 @@ export default function BarChart({
             type={type}
             isCommittee={isCommittee}
             showPercentages={showPercentages}
+            tooltip={tooltip}
           />
         </>
       ))}

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -128,7 +128,7 @@ export default function Candidate({ data }) {
                   data={Object.keys(FundingByType)
                     .filter(key => FundingByType[key] != null)
                     .map(key => ({
-                      label: ContributorCodes[key],
+                      ...ContributorCodes[key],
                       value: FundingByType[key],
                     }))
                     .sort((a, b) => b.value - a.value)}
@@ -153,7 +153,7 @@ export default function Candidate({ data }) {
                   data={Object.keys(ExpenditureByType)
                     .filter(key => ExpenditureByType[key] != null)
                     .map(key => ({
-                      label: ExpenditureCodes[key],
+                      ...ExpenditureCodes[key],
                       value: ExpenditureByType[key],
                     }))
                     .sort((a, b) => b.value - a.value)

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -156,8 +156,7 @@ export default function Candidate({ data }) {
                       ...ExpenditureCodes[key],
                       value: ExpenditureByType[key],
                     }))
-                    .sort((a, b) => b.value - a.value)
-                    .slice(0, 4)}
+                    .sort((a, b) => b.value - a.value)}
                 />
               </section>
               <section>


### PR DESCRIPTION
Added a tooltip for each contributor and expenditure code to provide more information. This currently uses the HTML title attribute so it's not accessible or mobile-friendly :( 

Also, show all expenditure codes with data instead of just the top 4.