### PR TITLE
Check if window exists

### DIFF
--- a/src/common/hooks/useWindowIsLarge.js
+++ b/src/common/hooks/useWindowIsLarge.js
@@ -4,7 +4,7 @@ const LARGE_WINDOW_SIZE = 760
 
 export default function useWindowIsLarge() {
   const [windowIsLarge, setWindowIsLarge] = useState(
-    window.innerWidth >= LARGE_WINDOW_SIZE
+    window && window.innerWidth >= LARGE_WINDOW_SIZE
   )
   const updateWindowDimensions = useCallback(() => {
     setWindowIsLarge(window.innerWidth >= LARGE_WINDOW_SIZE)


### PR DESCRIPTION
Apparently gatsby build does server-side rendering, and window doesn't exist then? Anyway, this is only used for the default value of useWindowIsLarge