### PR TITLE
Remove window usage from sideNav.js

### DIFF
--- a/src/common/hooks/useWindowIsLarge.js
+++ b/src/common/hooks/useWindowIsLarge.js
@@ -4,7 +4,7 @@ const LARGE_WINDOW_SIZE = 760
 
 export default function useWindowIsLarge() {
   const [windowIsLarge, setWindowIsLarge] = useState(
-    window && window.innerWidth >= LARGE_WINDOW_SIZE
+    typeof window !== "undefined" && window.innerWidth >= LARGE_WINDOW_SIZE
   )
   const updateWindowDimensions = useCallback(() => {
     setWindowIsLarge(window.innerWidth >= LARGE_WINDOW_SIZE)

--- a/src/components/sideNav.js
+++ b/src/components/sideNav.js
@@ -125,6 +125,7 @@ export default function sideNav({
   isCandidate = false,
   pageSubtitle,
   pageTitle,
+  selectedTitle,
 }) {
   return (
     <StaticQuery
@@ -166,11 +167,6 @@ export default function sideNav({
         const measureMenu = formatMenuForMeasures(Referendums)
         const candidateMenu = formatMenuForCandidates(OfficeElections)
         const menuOptions = [...candidateMenu, measureMenu]
-        let selectedTitle = window.location.href.split("/")
-        selectedTitle = selectedTitle[selectedTitle.length - 1]
-          .split("-")
-          .map(word => word[0].toUpperCase() + word.slice(1))
-          .join(" ")
 
         return (
           <div className={styles.outerContainer}>

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -49,6 +49,7 @@ export default function Candidate({ data }) {
         headerBackground="blue"
         pageTitle={Name}
         pageSubtitle={seat}
+        selectedTitle={seat}
       >
         <div className={styles.container}>
           <section>

--- a/src/templates/candidates.js
+++ b/src/templates/candidates.js
@@ -17,6 +17,7 @@ export default function Candidates({ data, pageContext }) {
           <SideNav
             pageTitle="Candidates"
             pageSubtitle="City of San José Candidates"
+            selectedTitle={officeElection.Title}
           >
             <div className={styles.candidateList}>
               <SectionHeader title={officeElection.Title} />

--- a/src/templates/referendum.js
+++ b/src/templates/referendum.js
@@ -25,9 +25,8 @@ const supportingCommittees = [
   },
 ]
 
-function MeasureDetails(props) {
-  const measure =
-    props.data?.allElection?.edges?.[0]?.node?.Referendums?.[0] ?? {}
+function MeasureDetails({ data }) {
+  const measure = data.referendum
   return (
     <Layout windowIsLarge={useWindowIsLarge()}>
       <SideNav
@@ -35,11 +34,12 @@ function MeasureDetails(props) {
         headerBackground="green"
         pageTitle="Measures"
         pageSubtitle="City of San José Ballot Measures"
+        selectedTitle={measure.Name}
       >
         <div className={styles.mainSection}>
           <SectionHeader
             isPageHeader
-            title={measure.Title}
+            title={measure.Name}
             subtitle="***TO REMOVE: PLACEHOLDER ONE LINE DESC OF MEASURE***"
           />
           <section>
@@ -89,25 +89,19 @@ function MeasureDetails(props) {
 }
 
 export const query = graphql`
-  query {
-    allElection {
-      edges {
-        node {
-          Referendums {
-            id
-            Name
-            Election {
-              ElectionCycle
-            }
-            Committee {
-              Name
-              TotalFunding
-            }
-            fields {
-              slug
-            }
-          }
-        }
+  query($id: String) {
+    referendum(id: { eq: $id }) {
+      id
+      Name
+      Election {
+        ElectionCycle
+      }
+      Committee {
+        Name
+        TotalFunding
+      }
+      fields {
+        slug
       }
     }
   }


### PR DESCRIPTION
Change referendum.js to use the passed-in id to query only for a specific measure, and pass in selectedTitle to sideNav so it doesn't need to get it from window.location.href. After these changes, `gatsby build` should work.