### PR TITLE
Fix issue where scroll doesn't get re-enabled from navbar

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,10 +1,11 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import styles from "./navbar.module.scss"
 import Logo from "./logo"
 import Menu from "./menu"
 import HamburgerIcon from "../common/hamburgerIcon"
 
 function disableScroll() {
+  document.body.style.overflow = "hidden"
   const scrollTop = window.pageYOffset || document.documentElement.scrollTop
   const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft
   window.onscroll = function() {
@@ -13,24 +14,19 @@ function disableScroll() {
 }
 
 function enableScroll() {
+  document.body.style.overflow = "visible"
   window.onscroll = function() {}
-}
-
-const handleClick = (menuIsOpen, setMenuIsOpen) => {
-  //TODO: Make only menu scroll in landscape mode
-
-  setMenuIsOpen(!menuIsOpen)
-  if (menuIsOpen) {
-    enableScroll()
-    document.body.style.overflow = "visible"
-  } else {
-    disableScroll()
-    document.body.style.overflow = "hidden"
-  }
 }
 
 export default function Navbar(props) {
   const [menuIsOpen, setMenuIsOpen] = useState(false)
+
+  useEffect(() => {
+    menuIsOpen ? disableScroll() : enableScroll()
+    // Return this function so it's called on unmount (just in case)
+    return enableScroll
+  }, [menuIsOpen])
+
   const links = [
     { name: "Home", endpoint: "/", hidden: true },
     ...props.links,
@@ -43,17 +39,15 @@ export default function Navbar(props) {
     { name: "Find your ballot", endpoint: "/", hidden: true },
   ]
 
-  if (menuIsOpen && props.windowIsLarge) {
-    handleClick(true, setMenuIsOpen)
-  }
-
   return (
     <nav className={styles.outerContainer}>
       <div className={styles.innerContainer}>
         <div className={styles.navbarTop}>
           <Logo header containerStyle={styles.logo} />
           <HamburgerIcon
-            handleClick={() => handleClick(menuIsOpen, setMenuIsOpen)}
+            handleClick={() => {
+              setMenuIsOpen(!menuIsOpen)
+            }}
             menuIsOpen={menuIsOpen}
           />
         </div>


### PR DESCRIPTION
We were seeing an issue where scrolling wouldn't get re-enabled when you clicked on a link in the nav bar menu to navigate to a new page - it would only re-enable scrolling when you explicitly closed the menu. It looks like `window.onscroll` was being reset properly, but `document.body.style.overflow` was only being updated in the menu's onClick. This PR simplifies the logic a bit so that we handle all the menu open/close behavior in the same useEffect callback.

I'm also returning enableScroll() from the useEffect just to make sure that scrolling is re-enabled, in case you navigate to a page that doesn't have the navbar on it somehow.