### PR TITLE
Clean up candidate page

### DIFF
--- a/src/components/bar.js
+++ b/src/components/bar.js
@@ -1,9 +1,11 @@
 import React from "react"
 import styles from "./bar.module.scss"
+import { formatPercent } from "../common/util/formatters"
 
-export default function Bar({ percent, type }) {
+export default function Bar({ ratio, type }) {
   const colorStyle =
     type === "expenditures" ? styles.expenditures : styles.contributions
+  const percent = formatPercent(ratio > 0 ? Math.max(ratio, 0.005) : 0)
   return (
     <div className={styles.barContainer}>
       <div className={styles.barBackground}>

--- a/src/components/barChart.js
+++ b/src/components/barChart.js
@@ -16,7 +16,6 @@ function Row({
   showPercentages,
   isCommittee,
 }) {
-  const percent = formatPercent(value / total)
   return (
     <div className={`${styles.row} ${isCommittee && styles.noLabel}`}>
       <div className={styles.rowTop}>
@@ -24,11 +23,13 @@ function Row({
           {label}
         </p>
         <p className={styles.value}>
-          {showPercentages ? percent : formatDollarsInThousands(value)}
+          {showPercentages
+            ? formatPercent(value / total)
+            : formatDollarsInThousands(value)}
         </p>
       </div>
       <div className={styles.rowBottom}>
-        <Bar percent={percent} type={type} />
+        <Bar ratio={value / total} type={type} />
       </div>
       {isCommittee && <div className={styles.padding} />}
     </div>

--- a/src/templates/candidate.js
+++ b/src/templates/candidate.js
@@ -127,7 +127,7 @@ export default function Candidate({ data }) {
                     }))
                     .sort((a, b) => b.value - a.value)}
                 />
-                <Link className={styles.seeAllLink} to="/">
+                {/* <Link className={styles.seeAllLink} to="/">
                   See all contributions
                   <div>
                     <img
@@ -136,7 +136,7 @@ export default function Candidate({ data }) {
                       src={ArrowIcon}
                     />
                   </div>
-                </Link>
+                </Link> */}
               </section>
               <section>
                 <ChartSection
@@ -160,7 +160,11 @@ export default function Candidate({ data }) {
                   id="balance"
                   total={TotalContributions}
                   data={[
-                    { label: "Within California", value: FundingByGeo.CA },
+                    { label: "Within San José", value: FundingByGeo.SJ },
+                    {
+                      label: "Within California",
+                      value: FundingByGeo.CA - FundingByGeo.SJ,
+                    },
                     { label: "Out of state", value: outOfStateFunding },
                   ]}
                   showPercentages
@@ -169,9 +173,9 @@ export default function Candidate({ data }) {
 
               {Committees && Committees.length > 0 ? (
                 <section className={styles.committees}>
-                  <SectionHeader title="Other committees controlled by candidate" />
+                  <SectionHeader title="Committees supporting this candidate" />
                   {data.candidate.Committees.map(({ Name }) => (
-                    <Link className={styles.committeeLink}>{Name}</Link>
+                    <p className={styles.committeeLink}>{Name}</p>
                   ))}
                 </section>
               ) : null}
@@ -197,6 +201,7 @@ export const query = graphql`
       }
       FundingByGeo {
         CA
+        SJ
       }
       ExpenditureByType {
         SAL


### PR DESCRIPTION
Misc. UI fixes for candidate page:
- Un-linkify committees since they don't go anywhere
- Remove 'See All Contributions' link for now
- Add a minimum sliver in the bar charts with small values > 0
- Update the Committees header text to indicate support vs. candidate owned
- Add SJ to the funding by geo breakdown