### PR TITLE
Overwrite TotalFunding with TotalRCPT (for now)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -130,13 +130,14 @@ exports.sourceNodes = async ({
     fetchEndpoint("metadata"),
   ])
   candidateData.Candidates.forEach(candidate => {
-    const { TotalRCPT, TotalLOAN } = candidate
-    // We're currently using RCPT because all the aggregations only use RCPT.
-    // TODO Include LOAN in TotalContributions
+    const { TotalRCPT } = candidate
+    // We're only including RCPT right now because the API only uses RCPT for aggregations
+    // TODO #171 Update to include LOAN
     const TotalContributions = TotalRCPT
     createNode({
       ...candidate,
       TotalContributions,
+      TotalFunding: TotalContributions, // TODO #171 Remove this override
       id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.ID}`),
       parent: null,
       children: [],
@@ -338,6 +339,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       Name: String!
       Committees: [Committee]
       TotalContributions: Float 
+      TotalFunding: Float
       TotalEXPN: Float
       TotalLOAN: Float
       TotalRCPT: Float


### PR DESCRIPTION
There are a few places where we use the TotalFunding field on candidate (which includes RCPT + LOAN) instead of TotalContributions (only RCPT). Since all of the candidate funding breakdowns and the office election TotalFunding field both only use RCPT, let's switch everything over to only using RCPT for now. Once the API has been updated to include LOAN, I'll update these fields so everything includes LOAN.