### PR TITLE
Fix lint errors in faq.js

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -5,27 +5,25 @@ import FAQItem from "../components/faqitem"
 import LandingPageHero from "../components/landingPageHero"
 import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
 
-const link = (href, text) => {
-  return <a href={href}>{text}</a>
-}
-
 const faq = [
   {
     sectionName: "About the data",
     questions: [
       {
         question: "Where does the data come from?",
-        answer: () => (
-          <p>
-            Candidates are legally required to file campaign finance forms.
-            These forms are then made available by the city of San José at{" "}
-            <a href="https://www.southtechhosting.com/SanJoseCity/CampaignDocsWebRetrieval/Search/SearchByElection.aspx">
-              this site
-            </a>
-            . We collect and aggregate the data from these campaign finance
-            forms and make it available to you here.
-          </p>
-        ),
+        answer: function dataResponse() {
+          return (
+            <p>
+              Candidates are legally required to file campaign finance forms.
+              These forms are then made available by the city of San José at{" "}
+              <a href="https://www.southtechhosting.com/SanJoseCity/CampaignDocsWebRetrieval/Search/SearchByElection.aspx">
+                this site
+              </a>
+              . We collect and aggregate the data from these campaign finance
+              forms and make it available to you here.
+            </p>
+          )
+        },
       },
       {
         question: "What data is featured on the website?",
@@ -40,49 +38,55 @@ const faq = [
       {
         question:
           "Who do I contact if I believe any of this data is incorrect?",
-        answer: () => (
-          <p>
-            Please submit your data correction request via email to{" "}
-            <a href="mailto:open-disclosure-san-jose@googlegroups.com">
-              open-disclosure-san-jose@googlegroups.com
-            </a>
-            .
-          </p>
-        ),
+        answer: function incorrectDataResponse() {
+          return (
+            <p>
+              Please submit your data correction request via email to{" "}
+              <a href="mailto:open-disclosure-san-jose@googlegroups.com">
+                open-disclosure-san-jose@googlegroups.com
+              </a>
+              .
+            </p>
+          )
+        },
       },
       {
-        question: "What are San José's campaign finance rules?",
-        answer: () => (
-          <>
-            <p>
-              The city of San José sets limits on how much non-candidates are
-              able to donate to a campaign. The candidate running for office can
-              donate as much as they want to themselves, but others can only
-              donate up to a certain amount that depends on the seat being
-              sought and whether or not the contribution is made before or after
-              the election.
-            </p>
-            <p>
-              Anonymous contributions are not allowed; all contributions must be
-              itemized no matter who they come from or their amount, and can
-              only be accepted during specific windows before and after the
-              election.
-            </p>
-            <p>
-              Contributions are non-transferrable to any committee the candidate
-              doesn’t control. To be eligible to transfer funds, the candidate
-              must have clearly notified contributors of that possibility on
-              their campaign materials. Any leftover funds must be returned to
-              the contributors or turned over to the city’s general fund.
-            </p>
-            <p>
-              Candidates are required to report their earnings and expenditures
-              at certain points during the campaign. The City Clerk has the
-              discretion to fine them for non-compliance up to the amount of the
-              difference in reported contributions and expenditures.
-            </p>
-          </>
-        ),
+        question: "What are San José’s campaign finance rules?",
+        answer: function campaignFinanceRulesResponse() {
+          return (
+            <>
+              <p>
+                The city of San José sets limits on how much non-candidates are
+                able to donate to a campaign. The candidate running for office
+                can donate as much as they want to themselves, but others can
+                only donate up to a certain amount that depends on the seat
+                being sought and whether or not the contribution is made before
+                or after the election.
+              </p>
+              <p>
+                Anonymous contributions are not allowed; all contributions must
+                be itemized no matter who they come from or their amount, and
+                can only be accepted during specific windows before and after
+                the election.
+              </p>
+              <p>
+                Contributions are non-transferrable to any committee the
+                candidate doesn’t control. To be eligible to transfer funds, the
+                candidate must have clearly notified contributors of that
+                possibility on their campaign materials. Any leftover funds must
+                be returned to the contributors or turned over to the city’s
+                general fund.
+              </p>
+              <p>
+                Candidates are required to report their earnings and
+                expenditures at certain points during the campaign. The City
+                Clerk has the discretion to fine them for non-compliance up to
+                the amount of the difference in reported contributions and
+                expenditures.
+              </p>
+            </>
+          )
+        },
       },
     ],
   },
@@ -91,41 +95,45 @@ const faq = [
     questions: [
       {
         question: "Does Open Disclosure endorse third-party candidates?",
-        answer: () => (
-          <>
-            <p>
-              In order to give users as much information about the candidate as
-              possible, we may link to content created by third parties
-              (including the candidate's website and social media accounts).
-              This information is not created or reviewed by us, and therefore
-              we cannot guarantee that it is completely impartial or factual.
-            </p>
-            <p>
-              We are not responsible or liable, directly or indirectly, for any
-              damage or loss caused or alleged to be caused by or in connection
-              to the use or reliance on any material available on or through
-              such websites. Open Disclosure San José is intended to be an
-              impartial source of information, and therefore neither support nor
-              oppose any political parties, candidates for public office, or
-              ballot measures.
-            </p>
-          </>
-        ),
+        answer: function thirdPartyEndorsementResponse() {
+          return (
+            <>
+              <p>
+                In order to give users as much information about the candidate
+                as possible, we may link to content created by third parties
+                (including the candidate’s website and social media accounts).
+                This information is not created or reviewed by us, and therefore
+                we cannot guarantee that it is completely impartial or factual.
+              </p>
+              <p>
+                We are not responsible or liable, directly or indirectly, for
+                any damage or loss caused or alleged to be caused by or in
+                connection to the use or reliance on any material available on
+                or through such websites. Open Disclosure San José is intended
+                to be an impartial source of information, and therefore neither
+                support nor oppose any political parties, candidates for public
+                office, or ballot measures.
+              </p>
+            </>
+          )
+        },
       },
       {
         question:
           "Where do I learn more about local candidates on the upcoming ballot?",
-        answer: () => (
-          <p>
-            You can learn more about local candidates via the{" "}
-            <a href="https://www.sccgov.org/sites/rov/Pages/Registrar-of-Voters.aspx">
-              Santa Clara County Registrar of Voters
-            </a>
-            , <a href="https://votersedge.org/ca">Voter's Edge</a>,{" "}
-            <a href="https://ballotpedia.org/">Ballotpedia</a>, or the
-            candidates' own websites and social media.
-          </p>
-        ),
+        answer: function learnMoreResponse() {
+          return (
+            <p>
+              You can learn more about local candidates via the{" "}
+              <a href="https://www.sccgov.org/sites/rov/Pages/Registrar-of-Voters.aspx">
+                Santa Clara County Registrar of Voters
+              </a>
+              , <a href="https://votersedge.org/ca">Voter’s Edge</a>,{" "}
+              <a href="https://ballotpedia.org/">Ballotpedia</a>, or the
+              candidates’ own websites and social media.
+            </p>
+          )
+        },
       },
       {
         question: "Does this site accept donations from local candidates?",
@@ -139,25 +147,27 @@ const faq = [
     questions: [
       {
         question: "Who is behind Open Disclosure San José?",
-        answer: () => (
-          <>
-            <p>
-              Open Disclosure San José is an open source, volunteer-developed
-              project by Code for San José aimed at making it easier for the
-              average voter to see where money comes from and goes to in local
-              municipal elections.
-            </p>
-            <p>
-              We believe that it is impractical to expect interested voters to
-              sift through hundreds of complex PDF and CSV files in order to
-              gain an understanding of a campaign's finances. However, we also
-              believe it is important that voters have this information in order
-              to make informed decisions when they vote. Therefore, our goal is
-              to aggregate and process the information contained in those
-              documents in one place in a user-friendly format.
-            </p>
-          </>
-        ),
+        answer: function aboutOpenDisclosureResponse() {
+          return (
+            <>
+              <p>
+                Open Disclosure San José is an open source, volunteer-developed
+                project by Code for San José aimed at making it easier for the
+                average voter to see where money comes from and goes to in local
+                municipal elections.
+              </p>
+              <p>
+                We believe that it is impractical to expect interested voters to
+                sift through hundreds of complex PDF and CSV files in order to
+                gain an understanding of a campaign’s finances. However, we also
+                believe it is important that voters have this information in
+                order to make informed decisions when they vote. Therefore, our
+                goal is to aggregate and process the information contained in
+                those documents in one place in a user-friendly format.
+              </p>
+            </>
+          )
+        },
       },
     ],
   },


### PR DESCRIPTION
It looks like lint errors are now causing gatsby to fail to build the JS bundle with `gatsby develop`. Cleaning up a few of the errors in faq.js:

- Giving names to functions that are used as React components
- Getting rid of ' and replacing it with ’ (it was complaining about using un-escaped single quote, replaced it with smart quotes because I think it looks better here anyway - San José's vs. San José’s)
- Remove unused function