### PR TITLE
Switch all funding totals in the UI to include LOAN 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -53,14 +53,9 @@ exports.sourceNodes = async ({
     fetchEndpoint("metadata"),
   ])
   candidateData.Candidates.forEach(candidate => {
-    const { TotalRCPT } = candidate
-    // We're only including RCPT right now because the API only uses RCPT for aggregations
-    // TODO #171 Update to include LOAN
-    const TotalContributions = TotalRCPT
     createNode({
       ...candidate,
-      TotalContributions,
-      TotalFunding: TotalContributions, // TODO #171 Remove this override
+      TotalContributions: candidate.TotalFunding,
       id: createNodeId(`${CANDIDATE_NODE_TYPE}-${candidate.ID}`),
       parent: null,
       children: [],

--- a/src/components/candidatesListItem.js
+++ b/src/components/candidatesListItem.js
@@ -1,4 +1,4 @@
-import { formatDollars, formatPercent } from "../common/util/formatters"
+import { formatDollars } from "../common/util/formatters"
 
 import Bar from "./bar"
 import { Link } from "gatsby"
@@ -13,7 +13,6 @@ export default function CandidatesListItem({
   TotalContributions,
   jsonNode,
 }) {
-  const percent = formatPercent(TotalContributions / electionTotal)
   return (
     <Link className={styles.container} to={path}>
       <img
@@ -36,7 +35,10 @@ export default function CandidatesListItem({
           </div>
         </div>
         <div className={styles.visualization}>
-          <Bar type="contributions" percent={percent} />
+          <Bar
+            type="contributions"
+            ratio={TotalContributions / electionTotal}
+          />
         </div>
       </div>
     </Link>


### PR DESCRIPTION
Now that @geleazar1000111 has made the change on the backend so that the breakdowns include LOAN, we can remove our overrides and include LOAN in everything in the UI.

Also fix something I broke on the candidates page (I changed the props of the Bar component without fixing this callsite).