### PR TITLE
Replace 'XXX' on home page with num calculated from candidate data

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,6 +23,7 @@ import learnMore from "./../../static/images/learnMore.png"
 import voteBlob from "./../../static/images/voteBlob.png"
 import registerToVote from "./../../static/images/registerToVote.png"
 import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
+import { formatPercent } from '../common/util/formatters'
 
 const formatDate = new Intl.DateTimeFormat("en-US", {
   dateStyle: "short",
@@ -76,6 +77,7 @@ export default function MainPage(props) {
   )
   let candidatesRunning = 0
   let candidateList = []
+  let totalSJ = 0
   if (OfficeElections) {
     OfficeElections.forEach(election => {
       candidatesRunning += election.Candidates.length
@@ -88,6 +90,7 @@ export default function MainPage(props) {
             image: candidate.jsonNode?.profilePhoto || BlankProfile,
             href: `/${ElectionDate}/candidate/${election.fields.slug}/${candidate.fields.slug}`,
           })
+          totalSJ += candidate.FundingByGeo.SJ
         }
       })
     })
@@ -115,7 +118,9 @@ export default function MainPage(props) {
     )} City of San José Campaign Finance Report`,
     items: [
       {
-        number: "XXX",
+        // This currently only includes data from candidates!
+        // TODO: Add measure funding data once we have it
+        number: formatPercent(totalSJ / TotalContributions),
         description: "Of donations from the city of San José",
       },
       {
@@ -262,6 +267,9 @@ export const query = graphql`
               TotalFunding
               fields {
                 slug
+              }
+              FundingByGeo {
+                SJ
               }
             }
           }


### PR DESCRIPTION
<img width="1356" alt="Screen Shot 2020-10-20 at 9 04 46 PM" src="https://user-images.githubusercontent.com/2308395/96671949-e873a280-1317-11eb-847e-1bdf85985105.png">

Calculating this by adding up all the SJ funding info from the candidates. We don't have funding data for measures yet, but we should add that once we do.