### PR TITLE
Make DateProcessed optional

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -335,7 +335,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type Metadata implements Node{
-      DateProcessed: String!
+      DateProcessed: String
     }
   `)
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -72,9 +72,7 @@ export default function MainPage(props) {
     OfficeElections,
     Referendums,
   } = props.data.allElection.edges[0].node
-  const lastScrape = new Date(
-    props.data.allMetadata.edges[0].node.DateProcessed
-  )
+  const {DateProcessed} = props.data.allMetadata.edges[0].node
   let candidatesRunning = 0
   let candidateList = []
   let totalSJ = 0
@@ -82,7 +80,6 @@ export default function MainPage(props) {
     OfficeElections.forEach(election => {
       candidatesRunning += election.Candidates.length
       election.Candidates.forEach(candidate => {
-        console.log(candidate)
         if (candidate) {
           candidateList.push({
             name: candidate.Name,
@@ -114,11 +111,10 @@ export default function MainPage(props) {
     ? `/${ElectionDate}/referendums/${Referendums[0].fields.slug}`
     : null
 
+  const lastScrape = DateProcessed ? formatDate.format(new Date(DateProcessed)) : ''
   const snapshot = {
     title: "San José live election snapshot",
-    description: `Source: ${formatDate.format(
-      lastScrape
-    )} City of San José Campaign Finance Report`,
+    description: `Source: ${lastScrape} City of San José Campaign Finance Report`,
     items: [
       {
         // This currently only includes data from candidates!


### PR DESCRIPTION
DateProcessed is currently a required field in our GraphQL schema, so if the backend doesn't provide it you get build errors on the frontend. This PR makes it optional, and only uses it in index.js if provided.

Here's what it looks like without the date:
<img width="754" alt="Screen Shot 2020-10-26 at 6 53 25 PM" src="https://user-images.githubusercontent.com/2308395/97247466-f9f7f700-17bc-11eb-92b4-6e30e67925d4.png">
