### PR TITLE
Update path for voters edge image

### DIFF
--- a/src/templates/referendum.js
+++ b/src/templates/referendum.js
@@ -7,7 +7,7 @@ import SideNav from "../components/sideNav"
 import SectionHeader from "../components/sectionHeader"
 import styles from "./referendum.module.scss"
 import useWindowIsLarge from "../common/hooks/useWindowIsLarge"
-import VotersEdgeIcon from "../../static/images/votersEdge.png"
+import VotersEdgeIcon from "../images/votersEdge.png"
 import CommitteeCharts from "../components/committeeCharts"
 
 function MeasureDetails({ data }) {


### PR DESCRIPTION
The import for the voters edge image in referendum.js is still referring to the old path, which causes a gatsby build failure. Updating the path to the new location in ../images