### PR TITLE
Changes denominator of bar graph

### DIFF
--- a/src/components/candidatesListItem.js
+++ b/src/components/candidatesListItem.js
@@ -9,8 +9,8 @@ import BlankProfile from "../images/blankProfile.webp"
 export default function CandidatesListItem({
   Name,
   path,
-  electionTotal,
   TotalContributions,
+  highestContributions,
   jsonNode,
 }) {
   return (
@@ -37,7 +37,7 @@ export default function CandidatesListItem({
         <div className={styles.visualization}>
           <Bar
             type="contributions"
-            ratio={TotalContributions / electionTotal}
+            ratio={TotalContributions / highestContributions}
           />
         </div>
       </div>

--- a/src/templates/candidates.js
+++ b/src/templates/candidates.js
@@ -11,12 +11,16 @@ import { sortInDescendingOrder } from "../common/util/sorting"
 export default function Candidates({ data, pageContext }) {
   const { electionDate } = pageContext
   const {
-    officeElection: { Title, Candidates, fields, TotalContributions },
+    officeElection: { Title, Candidates, fields },
   } = data
   const sortedCandidates = sortInDescendingOrder(
     Candidates,
     "TotalContributions"
   )
+  let highestContributions = 0
+  if (Candidates.length) {
+    highestContributions = sortedCandidates[0].TotalContributions
+  }
 
   return (
     <div className={styles.outerContainer}>
@@ -37,7 +41,7 @@ export default function Candidates({ data, pageContext }) {
                 <CandidatesListItem
                   path={`/${electionDate}/candidate/${fields.slug}/${candidate.fields.slug}`}
                   key={candidate.fields.slug}
-                  electionTotal={TotalContributions}
+                  highestContributions={highestContributions}
                   {...candidate}
                 />
               ))}


### PR DESCRIPTION
Gets the TotalContributions for most prolific earner (takes the 0th item's TotalContributions from the array sorted by highest to lowest TC) and uses that as the denominator rather than the TC of the entire election.

<img width="828" alt="Screen Shot 2020-11-02 at 8 05 11 PM" src="https://user-images.githubusercontent.com/25068419/97948886-b82ff900-1d46-11eb-98b2-df18fb7ffb9f.png">

#212 