### PR TITLE
Fixed overwriting downloaded files in headless mode

### DIFF
--- a/data_pipeline/scraper/scraper.py
+++ b/data_pipeline/scraper/scraper.py
@@ -248,15 +248,12 @@ class Scraper:
 
         options = webdriver.ChromeOptions()
 
-        # Uncomment block BELOW for headless data-retrieval
-        # --> Currently not working 100%, only downloads first link on form table
-        #isHeadless = os.environ.get('HEADLESS', False)
+        # enable headless data retrieval 
         isHeadless = os.environ.get('HEADLESS', True)
         if isHeadless:
             options.add_argument("--headless")
         options.add_argument("--disable-gpu")
         options.add_argument("--window-size=1280,800")
-        # Uncomment block ABOVE for headless data-retrieval
 
         options.add_argument("--ignore-certificate-errors")
         options.add_argument("--test_type")

--- a/data_pipeline/scraper/scraper.py
+++ b/data_pipeline/scraper/scraper.py
@@ -1,6 +1,6 @@
 import os
 import time
-import asyncio
+
 from time import sleep
 
 from selenium import webdriver

--- a/data_pipeline/scraper/scraper.py
+++ b/data_pipeline/scraper/scraper.py
@@ -126,14 +126,6 @@ class SjcWebsite:
                             os.rename('./data/transactionExportGrid.xls', renamedFile)
                             break
                         sleep(0.1)
-                    
-                    """
-                    sleep(1)
-                    if os.path.exists('./data/transactionExportGrid.xls'):
-                        countFile += 1
-                        renamedFile = './data/transactionExportGrid' + '(' + str(countFile) + ').xls'
-                        os.rename('./data/transactionExportGrid.xls', renamedFile)
-                    """
 
 
         print('NUM DOWNLOADS {}'.format(count))
@@ -313,7 +305,7 @@ class Scraper:
 
         # Custom module to aggregate data into single CSV
         self.website.preprocessing.aggregateData()
-
+"""
 start_time = time.time()
 s = Scraper()
 
@@ -325,3 +317,4 @@ print(
         time.strftime("%H:%M:%S", time.gmtime(time.time() - start_time))
     )
 )
+"""

--- a/data_pipeline/scraper/scraper.py
+++ b/data_pipeline/scraper/scraper.py
@@ -118,11 +118,22 @@ class SjcWebsite:
                 else:
                     downloadLinkElement.click()
                     count += 1
+                    
+                    while(1):
+                        if os.path.exists('./data/transactionExportGrid.xls'):
+                            countFile += 1
+                            renamedFile = './data/transactionExportGrid' + '(' + str(countFile) + ').xls'
+                            os.rename('./data/transactionExportGrid.xls', renamedFile)
+                            break
+                        sleep(0.1)
+                    
+                    """
                     sleep(1)
                     if os.path.exists('./data/transactionExportGrid.xls'):
                         countFile += 1
                         renamedFile = './data/transactionExportGrid' + '(' + str(countFile) + ').xls'
                         os.rename('./data/transactionExportGrid.xls', renamedFile)
+                    """
 
 
         print('NUM DOWNLOADS {}'.format(count))


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
Bug fix

- Describe what changes are being made
Modified scraper.py such that it renames the downloaded transactionExportGrid.xls file into transactionExportGrid.xls(1) or transactionExportGrid.xls(2) and so on. 

- Describe why these changes are being made
To avoid overwriting downloaded files in the headless mode

- List the use cases and edge cases relevant to this PR


- Describe how errors will be handled. How will we know if this code breaks in production


- Describe any external libraries/dependencies added or removed in this PR
None

- Describe any security risks are there regarding this change


- Describe how you tested these changes


- Link to relevant external documentation


--------------------------
### :clipboard: Mandatory Checklist

- [x] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [x] Have you discussed these changes with the project leader(s)?
- [x] Do all variable and function names communicate what they do?
- [] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->


--------------------------
### :blue_book: Glossary
- PR = Pull Request
